### PR TITLE
Add command intent model

### DIFF
--- a/src/main/java/com/talhanation/recruits/command/CommandIntent.java
+++ b/src/main/java/com/talhanation/recruits/command/CommandIntent.java
@@ -1,0 +1,106 @@
+package com.talhanation.recruits.command;
+
+import net.minecraft.world.phys.Vec3;
+
+import javax.annotation.Nullable;
+import java.util.UUID;
+
+/**
+ * First-class server-side representation of a player recruit command.
+ *
+ * <p>Network packets still define the wire format. Intents provide a common internal
+ * contract that later dispatcher, queue, and audit-log work can consume uniformly.</p>
+ */
+public sealed interface CommandIntent {
+
+    long issuedAtGameTime();
+
+    int priority();
+
+    boolean queueMode();
+
+    CommandIntentType type();
+
+    record Movement(
+            long issuedAtGameTime,
+            int priority,
+            boolean queueMode,
+            int movementState,
+            int formation,
+            boolean tight,
+            boolean holdFormation,
+            @Nullable Vec3 targetPos
+    ) implements CommandIntent {
+        @Override
+        public CommandIntentType type() {
+            return CommandIntentType.MOVEMENT;
+        }
+    }
+
+    record Face(
+            long issuedAtGameTime,
+            int priority,
+            boolean queueMode,
+            int formation,
+            boolean tight,
+            boolean holdFormation
+    ) implements CommandIntent {
+        @Override
+        public CommandIntentType type() {
+            return CommandIntentType.FACE;
+        }
+    }
+
+    record Attack(
+            long issuedAtGameTime,
+            int priority,
+            boolean queueMode,
+            UUID groupUuid
+    ) implements CommandIntent {
+        @Override
+        public CommandIntentType type() {
+            return CommandIntentType.ATTACK;
+        }
+    }
+
+    record StrategicFire(
+            long issuedAtGameTime,
+            int priority,
+            boolean queueMode,
+            UUID groupUuid,
+            boolean shouldFire
+    ) implements CommandIntent {
+        @Override
+        public CommandIntentType type() {
+            return CommandIntentType.STRATEGIC_FIRE;
+        }
+    }
+
+    record Aggro(
+            long issuedAtGameTime,
+            int priority,
+            boolean queueMode,
+            int state,
+            UUID groupUuid,
+            boolean fromGui
+    ) implements CommandIntent {
+        @Override
+        public CommandIntentType type() {
+            return CommandIntentType.AGGRO;
+        }
+    }
+
+    record SiegeMachine(
+            long issuedAtGameTime,
+            int priority,
+            boolean queueMode,
+            UUID mountUuid,
+            UUID groupUuid,
+            boolean returnToKnownMount
+    ) implements CommandIntent {
+        @Override
+        public CommandIntentType type() {
+            return CommandIntentType.SIEGE_MACHINE;
+        }
+    }
+}

--- a/src/main/java/com/talhanation/recruits/command/CommandIntentLog.java
+++ b/src/main/java/com/talhanation/recruits/command/CommandIntentLog.java
@@ -1,0 +1,71 @@
+package com.talhanation.recruits.command;
+
+import net.minecraft.server.level.ServerPlayer;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Per-player in-memory ring buffer of recently issued recruit commands.
+ */
+public final class CommandIntentLog {
+    public static final int MAX_ENTRIES_PER_PLAYER = 256;
+
+    private static final CommandIntentLog INSTANCE = new CommandIntentLog();
+
+    private final Map<UUID, Deque<Entry>> byPlayer = new ConcurrentHashMap<>();
+
+    private CommandIntentLog() {
+    }
+
+    public static CommandIntentLog instance() {
+        return INSTANCE;
+    }
+
+    public record Entry(UUID playerUuid, CommandIntent intent, int actorCount) {
+    }
+
+    public void record(ServerPlayer player, CommandIntent intent, int actorCount) {
+        if (player == null || intent == null) {
+            return;
+        }
+        Deque<Entry> deque = byPlayer.computeIfAbsent(player.getUUID(), ignored -> new ArrayDeque<>());
+        synchronized (deque) {
+            deque.addFirst(new Entry(player.getUUID(), intent, actorCount));
+            while (deque.size() > MAX_ENTRIES_PER_PLAYER) {
+                deque.pollLast();
+            }
+        }
+    }
+
+    public List<Entry> recentFor(UUID playerUuid) {
+        if (playerUuid == null) {
+            return List.of();
+        }
+        Deque<Entry> deque = byPlayer.get(playerUuid);
+        if (deque == null) {
+            return List.of();
+        }
+        synchronized (deque) {
+            return List.copyOf(deque);
+        }
+    }
+
+    public int sizeFor(UUID playerUuid) {
+        if (playerUuid == null) {
+            return 0;
+        }
+        Deque<Entry> deque = byPlayer.get(playerUuid);
+        return deque == null ? 0 : deque.size();
+    }
+
+    public void clearFor(UUID playerUuid) {
+        if (playerUuid != null) {
+            byPlayer.remove(playerUuid);
+        }
+    }
+}

--- a/src/main/java/com/talhanation/recruits/command/CommandIntentPriority.java
+++ b/src/main/java/com/talhanation/recruits/command/CommandIntentPriority.java
@@ -1,0 +1,14 @@
+package com.talhanation.recruits.command;
+
+/**
+ * Standard priority levels for queued recruit commands. Higher number means more urgent.
+ */
+public final class CommandIntentPriority {
+    public static final int LOW = 1;
+    public static final int NORMAL = 3;
+    public static final int HIGH = 5;
+    public static final int IMMEDIATE = 10;
+
+    private CommandIntentPriority() {
+    }
+}

--- a/src/main/java/com/talhanation/recruits/command/CommandIntentType.java
+++ b/src/main/java/com/talhanation/recruits/command/CommandIntentType.java
@@ -1,0 +1,13 @@
+package com.talhanation.recruits.command;
+
+/**
+ * Stable command verbs for server-side recruit command logging and dispatch.
+ */
+public enum CommandIntentType {
+    MOVEMENT,
+    FACE,
+    ATTACK,
+    STRATEGIC_FIRE,
+    AGGRO,
+    SIEGE_MACHINE
+}


### PR DESCRIPTION
## Summary
- Adds a server-side command intent data model for recruit commands.
- Adds stable command verb and priority constants for later dispatcher/queue PRs.
- Adds a bounded per-player in-memory command intent log.

## Verification
- Reviewed with code-reviewer: no findings after preserving upstream holdFormation fields.
- `./gradlew compileJava` could not complete because dependency resolution timed out fetching `curse.maven:siegeweapons-1259343:7906096` from CurseMaven; source compilation was not reached.

## Follow-up PRs
- Command target authority hardening.
- CommandIntentDispatcher wiring.
- Queue/runtime ticking and selected-subset RTS controls.