### PR TITLE
Harden recruit command authority

### DIFF
--- a/src/main/java/com/talhanation/recruits/command/CommandIntent.java
+++ b/src/main/java/com/talhanation/recruits/command/CommandIntent.java
@@ -1,0 +1,106 @@
+package com.talhanation.recruits.command;
+
+import net.minecraft.world.phys.Vec3;
+
+import javax.annotation.Nullable;
+import java.util.UUID;
+
+/**
+ * First-class server-side representation of a player recruit command.
+ *
+ * <p>Network packets still define the wire format. Intents provide a common internal
+ * contract that later dispatcher, queue, and audit-log work can consume uniformly.</p>
+ */
+public sealed interface CommandIntent {
+
+    long issuedAtGameTime();
+
+    int priority();
+
+    boolean queueMode();
+
+    CommandIntentType type();
+
+    record Movement(
+            long issuedAtGameTime,
+            int priority,
+            boolean queueMode,
+            int movementState,
+            int formation,
+            boolean tight,
+            boolean holdFormation,
+            @Nullable Vec3 targetPos
+    ) implements CommandIntent {
+        @Override
+        public CommandIntentType type() {
+            return CommandIntentType.MOVEMENT;
+        }
+    }
+
+    record Face(
+            long issuedAtGameTime,
+            int priority,
+            boolean queueMode,
+            int formation,
+            boolean tight,
+            boolean holdFormation
+    ) implements CommandIntent {
+        @Override
+        public CommandIntentType type() {
+            return CommandIntentType.FACE;
+        }
+    }
+
+    record Attack(
+            long issuedAtGameTime,
+            int priority,
+            boolean queueMode,
+            UUID groupUuid
+    ) implements CommandIntent {
+        @Override
+        public CommandIntentType type() {
+            return CommandIntentType.ATTACK;
+        }
+    }
+
+    record StrategicFire(
+            long issuedAtGameTime,
+            int priority,
+            boolean queueMode,
+            UUID groupUuid,
+            boolean shouldFire
+    ) implements CommandIntent {
+        @Override
+        public CommandIntentType type() {
+            return CommandIntentType.STRATEGIC_FIRE;
+        }
+    }
+
+    record Aggro(
+            long issuedAtGameTime,
+            int priority,
+            boolean queueMode,
+            int state,
+            UUID groupUuid,
+            boolean fromGui
+    ) implements CommandIntent {
+        @Override
+        public CommandIntentType type() {
+            return CommandIntentType.AGGRO;
+        }
+    }
+
+    record SiegeMachine(
+            long issuedAtGameTime,
+            int priority,
+            boolean queueMode,
+            UUID mountUuid,
+            UUID groupUuid,
+            boolean returnToKnownMount
+    ) implements CommandIntent {
+        @Override
+        public CommandIntentType type() {
+            return CommandIntentType.SIEGE_MACHINE;
+        }
+    }
+}

--- a/src/main/java/com/talhanation/recruits/command/CommandIntentDispatcher.java
+++ b/src/main/java/com/talhanation/recruits/command/CommandIntentDispatcher.java
@@ -1,0 +1,51 @@
+package com.talhanation.recruits.command;
+
+import com.talhanation.recruits.CommandEvents;
+import com.talhanation.recruits.entities.AbstractRecruitEntity;
+import net.minecraft.server.level.ServerPlayer;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+/**
+ * Single server-side entry point for recruit command intents.
+ */
+public final class CommandIntentDispatcher {
+    private CommandIntentDispatcher() {
+    }
+
+    public static CommandIntent dispatch(@Nullable ServerPlayer player, CommandIntent intent, List<AbstractRecruitEntity> actors) {
+        if (intent == null) {
+            return null;
+        }
+        List<AbstractRecruitEntity> safeActors = actors == null ? List.of() : actors;
+        CommandIntentLog.instance().record(player, intent, safeActors.size());
+        if (player == null || safeActors.isEmpty()) {
+            return intent;
+        }
+        applyIntentDirectly(player, intent, safeActors);
+        return intent;
+    }
+
+    static void applyIntentDirectly(ServerPlayer player, CommandIntent intent, List<AbstractRecruitEntity> actors) {
+        if (intent instanceof CommandIntent.Movement move) {
+            CommandEvents.onMovementCommand(player, actors, move.movementState(), move.formation(), move.tight(), move.holdFormation());
+        } else if (intent instanceof CommandIntent.Face face) {
+            CommandEvents.onFaceCommand(player, actors, face.formation(), face.tight(), face.holdFormation());
+        } else if (intent instanceof CommandIntent.Attack attack) {
+            CommandEvents.onAttackCommand(player, player.getUUID(), actors, attack.groupUuid());
+        } else if (intent instanceof CommandIntent.StrategicFire fire) {
+            for (AbstractRecruitEntity recruit : actors) {
+                CommandEvents.onStrategicFireCommand(player, player.getUUID(), recruit, fire.groupUuid(), fire.shouldFire());
+            }
+        } else if (intent instanceof CommandIntent.Aggro aggro) {
+            for (AbstractRecruitEntity recruit : actors) {
+                CommandEvents.onAggroCommand(player.getUUID(), recruit, aggro.state(), aggro.groupUuid(), aggro.fromGui());
+            }
+        } else if (intent instanceof CommandIntent.SiegeMachine siegeMachine) {
+            for (AbstractRecruitEntity recruit : actors) {
+                CommandEvents.onMountButton(player.getUUID(), recruit, siegeMachine.returnToKnownMount() ? null : siegeMachine.mountUuid(), siegeMachine.groupUuid());
+            }
+        }
+    }
+}

--- a/src/main/java/com/talhanation/recruits/command/CommandIntentLog.java
+++ b/src/main/java/com/talhanation/recruits/command/CommandIntentLog.java
@@ -1,0 +1,71 @@
+package com.talhanation.recruits.command;
+
+import net.minecraft.server.level.ServerPlayer;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Per-player in-memory ring buffer of recently issued recruit commands.
+ */
+public final class CommandIntentLog {
+    public static final int MAX_ENTRIES_PER_PLAYER = 256;
+
+    private static final CommandIntentLog INSTANCE = new CommandIntentLog();
+
+    private final Map<UUID, Deque<Entry>> byPlayer = new ConcurrentHashMap<>();
+
+    private CommandIntentLog() {
+    }
+
+    public static CommandIntentLog instance() {
+        return INSTANCE;
+    }
+
+    public record Entry(UUID playerUuid, CommandIntent intent, int actorCount) {
+    }
+
+    public void record(ServerPlayer player, CommandIntent intent, int actorCount) {
+        if (player == null || intent == null) {
+            return;
+        }
+        Deque<Entry> deque = byPlayer.computeIfAbsent(player.getUUID(), ignored -> new ArrayDeque<>());
+        synchronized (deque) {
+            deque.addFirst(new Entry(player.getUUID(), intent, actorCount));
+            while (deque.size() > MAX_ENTRIES_PER_PLAYER) {
+                deque.pollLast();
+            }
+        }
+    }
+
+    public List<Entry> recentFor(UUID playerUuid) {
+        if (playerUuid == null) {
+            return List.of();
+        }
+        Deque<Entry> deque = byPlayer.get(playerUuid);
+        if (deque == null) {
+            return List.of();
+        }
+        synchronized (deque) {
+            return List.copyOf(deque);
+        }
+    }
+
+    public int sizeFor(UUID playerUuid) {
+        if (playerUuid == null) {
+            return 0;
+        }
+        Deque<Entry> deque = byPlayer.get(playerUuid);
+        return deque == null ? 0 : deque.size();
+    }
+
+    public void clearFor(UUID playerUuid) {
+        if (playerUuid != null) {
+            byPlayer.remove(playerUuid);
+        }
+    }
+}

--- a/src/main/java/com/talhanation/recruits/command/CommandIntentPriority.java
+++ b/src/main/java/com/talhanation/recruits/command/CommandIntentPriority.java
@@ -1,0 +1,14 @@
+package com.talhanation.recruits.command;
+
+/**
+ * Standard priority levels for queued recruit commands. Higher number means more urgent.
+ */
+public final class CommandIntentPriority {
+    public static final int LOW = 1;
+    public static final int NORMAL = 3;
+    public static final int HIGH = 5;
+    public static final int IMMEDIATE = 10;
+
+    private CommandIntentPriority() {
+    }
+}

--- a/src/main/java/com/talhanation/recruits/command/CommandIntentType.java
+++ b/src/main/java/com/talhanation/recruits/command/CommandIntentType.java
@@ -1,0 +1,13 @@
+package com.talhanation.recruits.command;
+
+/**
+ * Stable command verbs for server-side recruit command logging and dispatch.
+ */
+public enum CommandIntentType {
+    MOVEMENT,
+    FACE,
+    ATTACK,
+    STRATEGIC_FIRE,
+    AGGRO,
+    SIEGE_MACHINE
+}

--- a/src/main/java/com/talhanation/recruits/command/RecruitCommandAuthority.java
+++ b/src/main/java/com/talhanation/recruits/command/RecruitCommandAuthority.java
@@ -1,0 +1,42 @@
+package com.talhanation.recruits.command;
+
+import com.talhanation.recruits.RecruitEvents;
+import com.talhanation.recruits.entities.AbstractRecruitEntity;
+import com.talhanation.recruits.world.RecruitsGroup;
+import net.minecraft.server.level.ServerPlayer;
+
+import javax.annotation.Nullable;
+import java.util.UUID;
+
+/**
+ * Server-side authority checks for recruit command and group mutations.
+ */
+public final class RecruitCommandAuthority {
+    private RecruitCommandAuthority() {
+    }
+
+    public static boolean canCommand(ServerPlayer player, AbstractRecruitEntity recruit) {
+        return player != null && recruit != null && recruit.isEffectedByCommand(player.getUUID());
+    }
+
+    public static boolean ownsRecruit(ServerPlayer player, AbstractRecruitEntity recruit) {
+        return player != null
+                && recruit != null
+                && recruit.isOwned()
+                && recruit.isAlive()
+                && player.getUUID().equals(recruit.getOwnerUUID());
+    }
+
+    public static boolean ownsGroup(ServerPlayer player, @Nullable UUID groupUuid) {
+        return ownedGroup(player, groupUuid) != null;
+    }
+
+    @Nullable
+    public static RecruitsGroup ownedGroup(ServerPlayer player, @Nullable UUID groupUuid) {
+        if (player == null || groupUuid == null || RecruitEvents.recruitsGroupsManager == null) {
+            return null;
+        }
+        RecruitsGroup group = RecruitEvents.recruitsGroupsManager.getGroup(groupUuid);
+        return group != null && player.getUUID().equals(group.getPlayerUUID()) ? group : null;
+    }
+}

--- a/src/main/java/com/talhanation/recruits/network/MessageAggro.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageAggro.java
@@ -1,18 +1,18 @@
 package com.talhanation.recruits.network;
 
-import com.talhanation.recruits.CommandEvents;
+import com.talhanation.recruits.command.CommandIntent;
+import com.talhanation.recruits.command.CommandIntentDispatcher;
+import com.talhanation.recruits.command.CommandIntentPriority;
 import com.talhanation.recruits.entities.AbstractRecruitEntity;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.world.phys.AABB;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.network.NetworkEvent;
 
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
-import java.util.function.Function;
 
 public class MessageAggro implements Message<MessageAggro> {
 
@@ -47,16 +47,18 @@ public class MessageAggro implements Message<MessageAggro> {
         }
 
 
-        player.getCommandSenderWorld().getEntitiesOfClass(
-                AbstractRecruitEntity.class,
-                player.getBoundingBox().inflate(boundBoxInflateModifier)
-        ).forEach((recruit) -> {
-            if (fromGui && !recruit.getUUID().equals(this.recruit)) {
-                return;
-            }
-
-            CommandEvents.onAggroCommand(this.player, recruit, this.state, group, fromGui);
-        });
+        List<AbstractRecruitEntity> recruits = fromGui
+                ? RecruitCommandTargetResolver.resolveOwnedRecruit(player, this.recruit, boundBoxInflateModifier).map(List::of).orElse(List.of())
+                : RecruitCommandTargetResolver.resolveGroupTargets(player, this.player, this.group, boundBoxInflateModifier);
+        CommandIntent intent = new CommandIntent.Aggro(
+                player.getCommandSenderWorld().getGameTime(),
+                CommandIntentPriority.NORMAL,
+                false,
+                this.state,
+                this.group,
+                this.fromGui
+        );
+        CommandIntentDispatcher.dispatch(player, intent, recruits);
     }
 
     public MessageAggro fromBytes(FriendlyByteBuf buf) {

--- a/src/main/java/com/talhanation/recruits/network/MessageAggroGui.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageAggroGui.java
@@ -1,6 +1,5 @@
 package com.talhanation.recruits.network;
 
-import com.talhanation.recruits.entities.AbstractRecruitEntity;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerPlayer;
@@ -29,11 +28,8 @@ public class MessageAggroGui implements Message<MessageAggroGui> {
 
     public void executeServerSide(NetworkEvent.Context context) {
         ServerPlayer player = Objects.requireNonNull(context.getSender());
-        player.getCommandSenderWorld().getEntitiesOfClass(
-                AbstractRecruitEntity.class,
-                player.getBoundingBox().inflate(16.0D),
-                (recruit) -> recruit.getUUID().equals(this.uuid)
-        ).forEach((recruit) -> recruit.setAggroState(this.state));
+        RecruitCommandTargetResolver.resolveOwnedRecruit(player, this.uuid, 16.0D)
+                .ifPresent((recruit) -> recruit.setAggroState(this.state));
     }
 
     public MessageAggroGui fromBytes(FriendlyByteBuf buf) {

--- a/src/main/java/com/talhanation/recruits/network/MessageApplyNoGroup.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageApplyNoGroup.java
@@ -1,9 +1,9 @@
 package com.talhanation.recruits.network;
 
+import com.talhanation.recruits.command.RecruitCommandAuthority;
 import com.talhanation.recruits.entities.AbstractRecruitEntity;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
-import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.Entity;
 import net.minecraftforge.api.distmarker.Dist;
@@ -30,12 +30,11 @@ public class MessageApplyNoGroup implements Message<MessageApplyNoGroup> {
 
     public void executeServerSide(NetworkEvent.Context context) {
         ServerPlayer player = Objects.requireNonNull(context.getSender());
+        if (!player.getUUID().equals(this.owner) || !RecruitCommandAuthority.ownsGroup(player, this.groupID)) return;
         List<AbstractRecruitEntity> recruitList = new ArrayList<>();
 
-        ServerLevel serverLevel = (ServerLevel) player.getCommandSenderWorld();
-
-        for(Entity entity : serverLevel.getEntities().getAll()){
-            if(entity instanceof AbstractRecruitEntity recruit && recruit.getGroup() != null && recruit.getGroup().equals(groupID))
+        for(Entity entity : player.serverLevel().getEntities().getAll()){
+            if(entity instanceof AbstractRecruitEntity recruit && recruit.getGroup() != null && recruit.getGroup().equals(groupID) && RecruitCommandAuthority.ownsRecruit(player, recruit))
                 recruitList.add(recruit);
         }
 

--- a/src/main/java/com/talhanation/recruits/network/MessageAssignGroupToCompanion.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageAssignGroupToCompanion.java
@@ -1,6 +1,7 @@
 package com.talhanation.recruits.network;
 
 import com.talhanation.recruits.RecruitEvents;
+import com.talhanation.recruits.command.RecruitCommandAuthority;
 import com.talhanation.recruits.entities.AbstractLeaderEntity;
 import com.talhanation.recruits.entities.AbstractRecruitEntity;
 import com.talhanation.recruits.entities.ICompanion;
@@ -35,6 +36,7 @@ public class MessageAssignGroupToCompanion implements Message<MessageAssignGroup
 
     public void executeServerSide(NetworkEvent.Context context) {
         ServerPlayer serverPlayer =  context.getSender();
+        if (serverPlayer == null || !serverPlayer.getUUID().equals(this.ownerUUID)) return;
         ServerLevel serverLevel =  serverPlayer.serverLevel();
 
         AbstractLeaderEntity companionEntity = null;
@@ -45,15 +47,15 @@ public class MessageAssignGroupToCompanion implements Message<MessageAssignGroup
         );
 
         for (LivingEntity companion : list){
-            if(companion.getUUID().equals(this.companionUUID)){
-                companionEntity = (AbstractLeaderEntity) companion;
+            if(companion.getUUID().equals(this.companionUUID) && companion instanceof AbstractLeaderEntity leader && RecruitCommandAuthority.canCommand(serverPlayer, leader)){
+                companionEntity = leader;
                 break;
             }
         }
         if(companionEntity == null) return;
 
 
-        RecruitsGroup group = RecruitEvents.recruitsGroupsManager.getGroup(companionEntity.getGroup());
+        RecruitsGroup group = RecruitCommandAuthority.ownedGroup(serverPlayer, companionEntity.getGroup());
         if(group == null) return;
 
         list.removeIf(living -> !(living instanceof AbstractRecruitEntity recruit)

--- a/src/main/java/com/talhanation/recruits/network/MessageAssignGroupToPlayer.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageAssignGroupToPlayer.java
@@ -2,6 +2,7 @@ package com.talhanation.recruits.network;
 
 import com.talhanation.recruits.FactionEvents;
 import com.talhanation.recruits.RecruitEvents;
+import com.talhanation.recruits.command.RecruitCommandAuthority;
 import com.talhanation.recruits.entities.AbstractRecruitEntity;
 import com.talhanation.recruits.world.RecruitsFaction;
 import com.talhanation.recruits.world.RecruitsGroup;
@@ -41,7 +42,8 @@ public class MessageAssignGroupToPlayer implements Message<MessageAssignGroupToP
 
     public void executeServerSide(NetworkEvent.Context context) {
         ServerPlayer player = Objects.requireNonNull(context.getSender());
-        RecruitsGroup group = RecruitEvents.recruitsGroupsManager.getGroup(groupUUID);
+        if (!player.getUUID().equals(this.owner)) return;
+        RecruitsGroup group = RecruitCommandAuthority.ownedGroup(player, groupUUID);
         ServerLevel serverLevel = (ServerLevel) player.getCommandSenderWorld();
         if(group == null) return;
 

--- a/src/main/java/com/talhanation/recruits/network/MessageAssignNearbyRecruitsInGroup.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageAssignNearbyRecruitsInGroup.java
@@ -1,6 +1,7 @@
 package com.talhanation.recruits.network;
 
 import com.talhanation.recruits.RecruitEvents;
+import com.talhanation.recruits.command.RecruitCommandAuthority;
 import com.talhanation.recruits.entities.AbstractRecruitEntity;
 import com.talhanation.recruits.world.RecruitsGroup;
 import de.maxhenkel.corelib.net.Message;
@@ -29,7 +30,7 @@ public class MessageAssignNearbyRecruitsInGroup implements Message<MessageAssign
 
     public void executeServerSide(NetworkEvent.Context context) {
         ServerPlayer player = Objects.requireNonNull(context.getSender());
-        RecruitsGroup newGroup = RecruitEvents.recruitsGroupsManager.getGroup(groupUUID);
+        RecruitsGroup newGroup = RecruitCommandAuthority.ownedGroup(player, groupUUID);
         if(newGroup == null) return;
 
         player.getCommandSenderWorld().getEntitiesOfClass(

--- a/src/main/java/com/talhanation/recruits/network/MessageAttack.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageAttack.java
@@ -1,9 +1,10 @@
 package com.talhanation.recruits.network;
 
-import com.talhanation.recruits.CommandEvents;
+import com.talhanation.recruits.command.CommandIntent;
+import com.talhanation.recruits.command.CommandIntentDispatcher;
+import com.talhanation.recruits.command.CommandIntentPriority;
 import com.talhanation.recruits.entities.AbstractRecruitEntity;
 import de.maxhenkel.corelib.net.Message;
-import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraftforge.api.distmarker.Dist;
@@ -32,12 +33,14 @@ public class MessageAttack implements Message<MessageAttack> {
 
     public void executeServerSide(NetworkEvent.Context context) {
         ServerPlayer serverPlayer = Objects.requireNonNull(context.getSender());
-        List<AbstractRecruitEntity> list = serverPlayer.getCommandSenderWorld().getEntitiesOfClass(
-                AbstractRecruitEntity.class,
-                serverPlayer.getBoundingBox().inflate(100)
+        List<AbstractRecruitEntity> list = RecruitCommandTargetResolver.resolveGroupTargets(serverPlayer, playerUuid, group, 100D);
+        CommandIntent intent = new CommandIntent.Attack(
+                serverPlayer.getCommandSenderWorld().getGameTime(),
+                CommandIntentPriority.NORMAL,
+                false,
+                group
         );
-
-        CommandEvents.onAttackCommand(serverPlayer, playerUuid, list, group);
+        CommandIntentDispatcher.dispatch(serverPlayer, intent, list);
     }
 
     public MessageAttack fromBytes(FriendlyByteBuf buf) {

--- a/src/main/java/com/talhanation/recruits/network/MessageClearTargetGui.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageClearTargetGui.java
@@ -1,7 +1,6 @@
 package com.talhanation.recruits.network;
 
 import com.talhanation.recruits.CommandEvents;
-import com.talhanation.recruits.entities.AbstractRecruitEntity;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerPlayer;
@@ -29,11 +28,11 @@ public class MessageClearTargetGui implements Message<MessageClearTargetGui> {
 
     public void executeServerSide(NetworkEvent.Context context) {
         ServerPlayer player = Objects.requireNonNull(context.getSender());
-        player.getCommandSenderWorld().getEntitiesOfClass(
-                AbstractRecruitEntity.class,
-                player.getBoundingBox().inflate(16.0D),
-                (recruit) -> recruit.getUUID().equals(this.recruit)
-        ).forEach((recruit) -> CommandEvents.onClearTargetButton(this.player, recruit, null));
+        if (!player.getUUID().equals(this.player)) {
+            return;
+        }
+        RecruitCommandTargetResolver.resolveOwnedRecruit(player, this.recruit, 16.0D)
+                .ifPresent((recruit) -> CommandEvents.onClearTargetButton(player.getUUID(), recruit, null));
     }
 
     public MessageClearTargetGui fromBytes(FriendlyByteBuf buf) {
@@ -47,4 +46,3 @@ public class MessageClearTargetGui implements Message<MessageClearTargetGui> {
         buf.writeUUID(this.recruit);
     }
 }
-

--- a/src/main/java/com/talhanation/recruits/network/MessageClearUpkeepGui.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageClearUpkeepGui.java
@@ -1,6 +1,5 @@
 package com.talhanation.recruits.network;
 
-import com.talhanation.recruits.entities.AbstractRecruitEntity;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerPlayer;
@@ -27,11 +26,7 @@ public class MessageClearUpkeepGui implements Message<MessageClearUpkeepGui> {
 
     public void executeServerSide(NetworkEvent.Context context){
         ServerPlayer player = Objects.requireNonNull(context.getSender());
-        player.getCommandSenderWorld().getEntitiesOfClass(
-                AbstractRecruitEntity.class,
-                player.getBoundingBox().inflate(16.0D),
-                (recruit) -> recruit.getUUID().equals(this.uuid)
-        ).forEach((recruit) -> {
+        RecruitCommandTargetResolver.resolveOwnedRecruit(player, this.uuid, 16.0D).ifPresent((recruit) -> {
             recruit.clearUpkeepPos();
             recruit.clearUpkeepEntity();
         });

--- a/src/main/java/com/talhanation/recruits/network/MessageDismountGui.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageDismountGui.java
@@ -1,7 +1,6 @@
 package com.talhanation.recruits.network;
 
 import com.talhanation.recruits.CommandEvents;
-import com.talhanation.recruits.entities.AbstractRecruitEntity;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerPlayer;
@@ -30,11 +29,11 @@ public class MessageDismountGui implements Message<MessageDismountGui> {
 
     public void executeServerSide(NetworkEvent.Context context) {
         ServerPlayer serverPlayer = Objects.requireNonNull(context.getSender());
-        serverPlayer.getCommandSenderWorld().getEntitiesOfClass(
-                AbstractRecruitEntity.class,
-                serverPlayer.getBoundingBox().inflate(16.0D),
-                (recruit) -> recruit.getUUID().equals(this.uuid)
-        ).forEach((recruit) -> CommandEvents.onDismountButton(player, recruit, null));
+        if (!serverPlayer.getUUID().equals(this.player)) {
+            return;
+        }
+        RecruitCommandTargetResolver.resolveOwnedRecruit(serverPlayer, this.uuid, 16.0D)
+                .ifPresent((recruit) -> CommandEvents.onDismountButton(serverPlayer.getUUID(), recruit, null));
     }
 
     public MessageDismountGui fromBytes(FriendlyByteBuf buf) {

--- a/src/main/java/com/talhanation/recruits/network/MessageFaceCommand.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageFaceCommand.java
@@ -1,6 +1,8 @@
 package com.talhanation.recruits.network;
 
-import com.talhanation.recruits.CommandEvents;
+import com.talhanation.recruits.command.CommandIntent;
+import com.talhanation.recruits.command.CommandIntentDispatcher;
+import com.talhanation.recruits.command.CommandIntentPriority;
 import com.talhanation.recruits.entities.AbstractRecruitEntity;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
@@ -35,10 +37,17 @@ public class MessageFaceCommand implements Message<MessageFaceCommand> {
     }
 
     public void executeServerSide(NetworkEvent.Context context){
-        List<AbstractRecruitEntity> list = Objects.requireNonNull(context.getSender()).getCommandSenderWorld().getEntitiesOfClass(AbstractRecruitEntity.class, context.getSender().getBoundingBox().inflate(100));
-        list.removeIf(recruit -> !recruit.isEffectedByCommand(this.player_uuid, this.group));
-
-        CommandEvents.onFaceCommand(context.getSender(), list, this.formation, this.tight, this.hold);
+        var sender = Objects.requireNonNull(context.getSender());
+        List<AbstractRecruitEntity> list = RecruitCommandTargetResolver.resolveGroupTargets(sender, this.player_uuid, this.group, 100D);
+        CommandIntent intent = new CommandIntent.Face(
+                sender.getCommandSenderWorld().getGameTime(),
+                CommandIntentPriority.NORMAL,
+                false,
+                this.formation,
+                this.tight,
+                this.hold
+        );
+        CommandIntentDispatcher.dispatch(sender, intent, list);
     }
 
     public MessageFaceCommand fromBytes(FriendlyByteBuf buf) {

--- a/src/main/java/com/talhanation/recruits/network/MessageFollowGui.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageFollowGui.java
@@ -1,15 +1,12 @@
 package com.talhanation.recruits.network;
 
 import com.talhanation.recruits.CommandEvents;
-import com.talhanation.recruits.entities.AbstractRecruitEntity;
-import com.talhanation.recruits.entities.VillagerNobleEntity;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.network.NetworkEvent;
 
-import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -32,11 +29,8 @@ public class MessageFollowGui implements Message<MessageFollowGui> {
 
     public void executeServerSide(NetworkEvent.Context context) {
         ServerPlayer serverPlayer = Objects.requireNonNull(context.getSender());
-        serverPlayer.getCommandSenderWorld().getEntitiesOfClass(
-                AbstractRecruitEntity.class,
-                serverPlayer.getBoundingBox().inflate(16.0D),
-                (recruit) -> recruit.getUUID().equals(this.uuid)
-        ).forEach((recruit) -> CommandEvents.onMovementCommandGUI(recruit, state));
+        RecruitCommandTargetResolver.resolveOwnedRecruit(serverPlayer, this.uuid, 16.0D)
+                .ifPresent((recruit) -> CommandEvents.onMovementCommandGUI(recruit, state));
     }
 
     public MessageFollowGui fromBytes(FriendlyByteBuf buf) {

--- a/src/main/java/com/talhanation/recruits/network/MessageGroup.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageGroup.java
@@ -1,6 +1,7 @@
 package com.talhanation.recruits.network;
 
 import com.talhanation.recruits.RecruitEvents;
+import com.talhanation.recruits.command.RecruitCommandAuthority;
 import com.talhanation.recruits.entities.AbstractRecruitEntity;
 import com.talhanation.recruits.world.RecruitsGroup;
 import de.maxhenkel.corelib.net.Message;
@@ -32,16 +33,14 @@ public class MessageGroup implements Message<MessageGroup> {
 
     public void executeServerSide(NetworkEvent.Context context) {
         ServerPlayer player = Objects.requireNonNull(context.getSender());
-        player.getCommandSenderWorld().getEntitiesOfClass(
-                AbstractRecruitEntity.class,
-                player.getBoundingBox().inflate(100),
-                (recruit) -> recruit.getUUID().equals(this.recruitUUID)
-        ).forEach((recruit) -> this.setGroup(recruit, player, groupUUID));
+        RecruitCommandTargetResolver.resolveOwnedRecruit(player, this.recruitUUID, 100D)
+                .ifPresent((recruit) -> this.setGroup(recruit, player, groupUUID));
     }
 
     public void setGroup(AbstractRecruitEntity recruit, ServerPlayer player , UUID groupUUID){
         RecruitsGroup oldGroup = RecruitEvents.recruitsGroupsManager.getGroup(recruit.getGroup());
-        RecruitsGroup newGroup = RecruitEvents.recruitsGroupsManager.getGroup(groupUUID);
+        RecruitsGroup newGroup = RecruitCommandAuthority.ownedGroup(player, groupUUID);
+        if (newGroup == null) return;
         if(oldGroup != null && newGroup != null && oldGroup.getUUID().equals(newGroup.getUUID())) return;
 
         if(oldGroup != null) RecruitEvents.recruitsGroupsManager.removeMember(oldGroup.getUUID(), recruit.getUUID(), player.serverLevel());

--- a/src/main/java/com/talhanation/recruits/network/MessageListen.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageListen.java
@@ -1,6 +1,5 @@
 package com.talhanation.recruits.network;
 
-import com.talhanation.recruits.entities.AbstractRecruitEntity;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerPlayer;
@@ -29,11 +28,8 @@ public class MessageListen implements Message<MessageListen> {
 
     public void executeServerSide(NetworkEvent.Context context) {
         ServerPlayer player = Objects.requireNonNull(context.getSender());
-        player.getCommandSenderWorld().getEntitiesOfClass(
-                AbstractRecruitEntity.class,
-                player.getBoundingBox().inflate(100),
-                (recruit) -> recruit.getUUID().equals(this.uuid)
-        ).forEach((recruit) -> recruit.setListen(bool));
+        RecruitCommandTargetResolver.resolveOwnedRecruit(player, this.uuid, 100D, false)
+                .ifPresent((recruit) -> recruit.setListen(bool));
     }
 
     public MessageListen fromBytes(FriendlyByteBuf buf) {

--- a/src/main/java/com/talhanation/recruits/network/MessageMountEntityGui.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageMountEntityGui.java
@@ -41,15 +41,12 @@ public class MessageMountEntityGui implements Message<MessageMountEntityGui> {
     public void executeServerSide(NetworkEvent.Context context) {
         ServerPlayer player = Objects.requireNonNull(context.getSender());
 
-        player.getCommandSenderWorld().getEntitiesOfClass(
-                AbstractRecruitEntity.class,
-                player.getBoundingBox().inflate(32.0D),
-                v -> v.getUUID().equals(this.recruit) && v.isAlive()
-        ).forEach(this::mount);
+        RecruitCommandTargetResolver.resolveOwnedRecruit(player, this.recruit, 32.0D)
+                .ifPresent(recruit -> this.mount(player, recruit));
     }
 
     @SuppressWarnings({"all"})
-    private void mount(AbstractRecruitEntity recruit) {
+    private void mount(ServerPlayer player, AbstractRecruitEntity recruit) {
         if (this.back && recruit.getMountUUID() != null) {
             recruit.shouldMount(true, recruit.getMountUUID());
         } else if (recruit.getVehicle() == null) {
@@ -71,7 +68,7 @@ public class MessageMountEntityGui implements Message<MessageMountEntityGui> {
             }
 
             if (horse == null) {
-                recruit.getOwner().sendSystemMessage(TEXT_NO_MOUNT(recruit.getName().getString()));
+                player.sendSystemMessage(TEXT_NO_MOUNT(recruit.getName().getString()));
                 return;
             }
 

--- a/src/main/java/com/talhanation/recruits/network/MessageMovement.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageMovement.java
@@ -1,6 +1,8 @@
 package com.talhanation.recruits.network;
 
-import com.talhanation.recruits.CommandEvents;
+import com.talhanation.recruits.command.CommandIntent;
+import com.talhanation.recruits.command.CommandIntentDispatcher;
+import com.talhanation.recruits.command.CommandIntentPriority;
 import com.talhanation.recruits.entities.AbstractRecruitEntity;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
@@ -37,12 +39,19 @@ public class MessageMovement implements Message<MessageMovement> {
     }
 
     public void executeServerSide(NetworkEvent.Context context){
-        List<AbstractRecruitEntity> list = Objects.requireNonNull(context.getSender()).getCommandSenderWorld().getEntitiesOfClass(AbstractRecruitEntity.class, context.getSender().getBoundingBox().inflate(100));
-        list.removeIf(recruit -> !recruit.isEffectedByCommand(this.player_uuid, this.group));
-
-
-
-        CommandEvents.onMovementCommand(context.getSender(), list, this.state, this.formation, this.tight, this.hold);
+        var sender = Objects.requireNonNull(context.getSender());
+        List<AbstractRecruitEntity> list = RecruitCommandTargetResolver.resolveGroupTargets(sender, this.player_uuid, this.group, 100D);
+        CommandIntent intent = new CommandIntent.Movement(
+                sender.getCommandSenderWorld().getGameTime(),
+                CommandIntentPriority.NORMAL,
+                false,
+                this.state,
+                this.formation,
+                this.tight,
+                this.hold,
+                null
+        );
+        CommandIntentDispatcher.dispatch(sender, intent, list);
     }
 
     public MessageMovement fromBytes(FriendlyByteBuf buf) {

--- a/src/main/java/com/talhanation/recruits/network/MessageRemoveAssignedGroupFromCompanion.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageRemoveAssignedGroupFromCompanion.java
@@ -2,7 +2,7 @@ package com.talhanation.recruits.network;
 
 import com.talhanation.recruits.Main;
 import com.talhanation.recruits.RecruitEvents;
-import com.talhanation.recruits.entities.AbstractLeaderEntity;
+import com.talhanation.recruits.command.RecruitCommandAuthority;
 import com.talhanation.recruits.entities.AbstractRecruitEntity;
 import com.talhanation.recruits.entities.ICompanion;
 import com.talhanation.recruits.util.RecruitCommanderUtil;
@@ -35,13 +35,11 @@ public class MessageRemoveAssignedGroupFromCompanion implements Message<MessageR
 
     public void executeServerSide(NetworkEvent.Context context) {
         ServerPlayer serverPlayer = context.getSender();
-        serverPlayer.serverLevel().getEntitiesOfClass(AbstractLeaderEntity.class,
-                context.getSender().getBoundingBox().inflate(100D),
-                (leader) -> leader.getUUID().equals(this.companion)
-        ).forEach((companionEntity) -> {
+        if (serverPlayer == null || !serverPlayer.getUUID().equals(this.owner)) return;
+        RecruitCommandTargetResolver.resolveOwnedLeader(serverPlayer, this.companion, 100D).ifPresent((companionEntity) -> {
             if(companionEntity == null) return;
 
-            RecruitsGroup group = RecruitEvents.recruitsGroupsManager.getGroup(companionEntity.getGroup());
+            RecruitsGroup group = RecruitCommandAuthority.ownedGroup(serverPlayer, companionEntity.getGroup());
             if(group == null) return;
             group.leaderUUID = null;
             companionEntity.setGroupUUID(group.getUUID());

--- a/src/main/java/com/talhanation/recruits/network/MessageSetLeaderGroup.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageSetLeaderGroup.java
@@ -1,7 +1,7 @@
 package com.talhanation.recruits.network;
 
 import com.talhanation.recruits.RecruitEvents;
-import com.talhanation.recruits.entities.AbstractLeaderEntity;
+import com.talhanation.recruits.command.RecruitCommandAuthority;
 import com.talhanation.recruits.world.RecruitsGroup;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
@@ -11,7 +11,6 @@ import net.minecraftforge.network.NetworkEvent;
 
 import javax.annotation.Nullable;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -39,16 +38,12 @@ public class MessageSetLeaderGroup implements Message<MessageSetLeaderGroup> {
     @Override
     public void executeServerSide(NetworkEvent.Context context) {
         ServerPlayer player = Objects.requireNonNull(context.getSender());
-        player.serverLevel().getEntitiesOfClass(
-                AbstractLeaderEntity.class,
-                player.getBoundingBox().inflate(100D),
-                leader -> leader.getUUID().equals(this.leaderUUID) && leader.isAlive()
-        ).forEach(leader -> {
+        RecruitCommandTargetResolver.resolveOwnedLeader(player, this.leaderUUID, 100D).ifPresent(leader -> {
             if (groupUUID == null) {
                 leader.setGroupUUID(null);
                 return;
             }
-            RecruitsGroup group = RecruitEvents.recruitsGroupsManager.getGroup(groupUUID);
+            RecruitsGroup group = RecruitCommandAuthority.ownedGroup(player, groupUUID);
             if (group == null) return;
             leader.setGroupUUID(group.getUUID());
             RecruitEvents.recruitsGroupsManager.broadCastGroupsToPlayer(player);

--- a/src/main/java/com/talhanation/recruits/network/MessageStrategicFire.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageStrategicFire.java
@@ -1,6 +1,8 @@
 package com.talhanation.recruits.network;
 
-import com.talhanation.recruits.CommandEvents;
+import com.talhanation.recruits.command.CommandIntent;
+import com.talhanation.recruits.command.CommandIntentDispatcher;
+import com.talhanation.recruits.command.CommandIntentPriority;
 import com.talhanation.recruits.entities.AbstractRecruitEntity;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
@@ -33,18 +35,15 @@ public class MessageStrategicFire implements Message<MessageStrategicFire> {
 
     public void executeServerSide(NetworkEvent.Context context) {
         ServerPlayer serverPlayer = Objects.requireNonNull(context.getSender());
-        serverPlayer.getCommandSenderWorld().getEntitiesOfClass(
-                AbstractRecruitEntity.class,
-                serverPlayer.getBoundingBox().inflate(200)
-        ).forEach((recruit) ->
-                CommandEvents.onStrategicFireCommand(
-                        serverPlayer,
-                        this.player,
-                        recruit,
-                        group,
-                        should
-                )
+        List<AbstractRecruitEntity> recruits = RecruitCommandTargetResolver.resolveGroupTargets(serverPlayer, this.player, this.group, 200D);
+        CommandIntent intent = new CommandIntent.StrategicFire(
+                serverPlayer.getCommandSenderWorld().getGameTime(),
+                CommandIntentPriority.NORMAL,
+                false,
+                this.group,
+                this.should
         );
+        CommandIntentDispatcher.dispatch(serverPlayer, intent, recruits);
     }
 
     public MessageStrategicFire fromBytes(FriendlyByteBuf buf) {

--- a/src/main/java/com/talhanation/recruits/network/MessageUpdateGroup.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageUpdateGroup.java
@@ -1,9 +1,7 @@
 package com.talhanation.recruits.network;
 
-import com.talhanation.recruits.CommandEvents;
 import com.talhanation.recruits.RecruitEvents;
 import com.talhanation.recruits.world.RecruitsGroup;
-import com.talhanation.recruits.world.RecruitsGroupsManager;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.FriendlyByteBuf;
@@ -32,6 +30,10 @@ public class MessageUpdateGroup implements Message<MessageUpdateGroup> {
     public void executeServerSide(NetworkEvent.Context context){
         RecruitsGroup updatedGroup = RecruitsGroup.fromNBT(this.groupNBT);
         ServerPlayer serverPLayer = context.getSender();
+        if (serverPLayer == null || updatedGroup == null) return;
+        if (!serverPLayer.getUUID().equals(updatedGroup.getPlayerUUID())) return;
+        RecruitsGroup existingGroup = RecruitEvents.recruitsGroupsManager.getGroup(updatedGroup.getUUID());
+        if (existingGroup != null && !serverPLayer.getUUID().equals(existingGroup.getPlayerUUID())) return;
 
         RecruitEvents.recruitsGroupsManager.addOrUpdateGroup((ServerLevel) serverPLayer.getCommandSenderWorld(), serverPLayer, updatedGroup);
     }

--- a/src/main/java/com/talhanation/recruits/network/RecruitCommandTargetResolver.java
+++ b/src/main/java/com/talhanation/recruits/network/RecruitCommandTargetResolver.java
@@ -1,0 +1,55 @@
+package com.talhanation.recruits.network;
+
+import com.talhanation.recruits.command.RecruitCommandAuthority;
+import com.talhanation.recruits.entities.AbstractLeaderEntity;
+import com.talhanation.recruits.entities.AbstractRecruitEntity;
+import net.minecraft.server.level.ServerPlayer;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+final class RecruitCommandTargetResolver {
+    private RecruitCommandTargetResolver() {
+    }
+
+    static List<AbstractRecruitEntity> resolveGroupTargets(ServerPlayer sender, UUID claimedPlayerUuid, UUID groupUuid, double radius) {
+        if (sender == null || claimedPlayerUuid == null || !sender.getUUID().equals(claimedPlayerUuid)) {
+            return List.of();
+        }
+        return sender.getCommandSenderWorld().getEntitiesOfClass(
+                AbstractRecruitEntity.class,
+                sender.getBoundingBox().inflate(radius),
+                recruit -> recruit.isEffectedByCommand(sender.getUUID(), groupUuid)
+        );
+    }
+
+    static Optional<AbstractRecruitEntity> resolveOwnedRecruit(ServerPlayer sender, UUID recruitUuid, double radius) {
+        return resolveOwnedRecruit(sender, recruitUuid, radius, true);
+    }
+
+    static Optional<AbstractRecruitEntity> resolveOwnedRecruit(ServerPlayer sender, UUID recruitUuid, double radius, boolean requireListen) {
+        if (sender == null || recruitUuid == null) {
+            return Optional.empty();
+        }
+        return sender.getCommandSenderWorld().getEntitiesOfClass(
+                AbstractRecruitEntity.class,
+                sender.getBoundingBox().inflate(radius),
+                recruit -> recruit.getUUID().equals(recruitUuid)
+                        && (requireListen
+                        ? RecruitCommandAuthority.canCommand(sender, recruit)
+                        : RecruitCommandAuthority.ownsRecruit(sender, recruit))
+        ).stream().findFirst();
+    }
+
+    static Optional<AbstractLeaderEntity> resolveOwnedLeader(ServerPlayer sender, UUID leaderUuid, double radius) {
+        if (sender == null || leaderUuid == null) {
+            return Optional.empty();
+        }
+        return sender.getCommandSenderWorld().getEntitiesOfClass(
+                AbstractLeaderEntity.class,
+                sender.getBoundingBox().inflate(radius),
+                leader -> leader.getUUID().equals(leaderUuid) && RecruitCommandAuthority.canCommand(sender, leader)
+        ).stream().findFirst();
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a server-side command intent model, dispatcher seam, bounded command log, and authority helper.
- Rewires movement, face, attack, strategic-fire, aggro, mount/listen, and GUI recruit commands through server-resolved owned targets instead of trusting client UUIDs.
- Guards group and leader assignment mutations with sender/group ownership checks while preserving new group creation and listen re-enable behavior.

## Verification
- `source ~/.sdkman/bin/sdkman-init.sh && ./gradlew compileJava`
- code-simplifier cleanup pass completed.
- code-reviewer findings resolved: group creation preserved, listen=false recovery preserved, apply-no-group handles non-listening owned recruits.

## Notes
- This replaces the smaller command-intent-only PR with a fuller command-pipeline authority slice.