### PR TITLE
Harden remaining recruit action packets

### DIFF
--- a/src/main/java/com/talhanation/recruits/network/MessageAssignRecruitToPlayer.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageAssignRecruitToPlayer.java
@@ -1,7 +1,9 @@
 package com.talhanation.recruits.network;
 
 import com.talhanation.recruits.FactionEvents;
+import com.talhanation.recruits.command.RecruitCommandAuthority;
 import com.talhanation.recruits.entities.AbstractRecruitEntity;
+import com.talhanation.recruits.world.RecruitsFaction;
 import com.talhanation.recruits.world.RecruitsPlayerInfo;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
@@ -10,7 +12,6 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.network.NetworkEvent;
 
-import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -31,17 +32,29 @@ public class MessageAssignRecruitToPlayer implements Message<MessageAssignRecrui
     }
 
     public void executeServerSide(NetworkEvent.Context context) {
-        ServerPlayer serverPlayer = context.getSender();
-        List<AbstractRecruitEntity> list = Objects.requireNonNull(context.getSender()).getCommandSenderWorld().getEntitiesOfClass(AbstractRecruitEntity.class, context.getSender().getBoundingBox().inflate(64.0D));
+        ServerPlayer serverPlayer = Objects.requireNonNull(context.getSender());
         ServerLevel serverLevel = (ServerLevel) serverPlayer.getCommandSenderWorld();
 
-        for (AbstractRecruitEntity recruit : list) {
-            if(recruit.getUUID().equals(this.recruit)){
-                recruit.assignToPlayer(newOwner, null);
-                FactionEvents.notifyPlayer(serverLevel, new RecruitsPlayerInfo(newOwner, ""), 0, serverPlayer.getName().getString());
-                break;
-            }
+        serverPlayer.getCommandSenderWorld().getEntitiesOfClass(
+                AbstractRecruitEntity.class,
+                serverPlayer.getBoundingBox().inflate(64.0D),
+                recruit -> recruit.getUUID().equals(this.recruit) && canAssign(serverPlayer, recruit)
+        ).stream().findFirst()
+                .ifPresent(recruit -> {
+                    recruit.assignToPlayer(newOwner, null);
+                    FactionEvents.notifyPlayer(serverLevel, new RecruitsPlayerInfo(newOwner, ""), 0, serverPlayer.getName().getString());
+                });
+    }
+
+    private boolean canAssign(ServerPlayer player, AbstractRecruitEntity recruit) {
+        if (RecruitCommandAuthority.ownsRecruit(player, recruit)) {
+            return true;
         }
+        if (!player.getUUID().equals(this.newOwner) || !recruit.isOwned() || recruit.getTeam() == null) {
+            return false;
+        }
+        RecruitsFaction faction = FactionEvents.recruitsFactionManager.getFactionByStringID(recruit.getTeam().getName());
+        return faction != null && player.getUUID().equals(faction.getTeamLeaderUUID());
     }
 
     public MessageAssignRecruitToPlayer fromBytes(FriendlyByteBuf buf) {

--- a/src/main/java/com/talhanation/recruits/network/MessageBackToMountEntity.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageBackToMountEntity.java
@@ -1,7 +1,6 @@
 package com.talhanation.recruits.network;
 
 import com.talhanation.recruits.CommandEvents;
-import com.talhanation.recruits.entities.AbstractRecruitEntity;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerPlayer;
@@ -31,10 +30,8 @@ public class MessageBackToMountEntity implements Message<MessageBackToMountEntit
 
     public void executeServerSide(NetworkEvent.Context context) {
         ServerPlayer player = Objects.requireNonNull(context.getSender());
-        player.getCommandSenderWorld().getEntitiesOfClass(
-                AbstractRecruitEntity.class,
-                context.getSender().getBoundingBox().inflate(100)
-        ).forEach((recruit) -> CommandEvents.onMountButton(uuid, recruit, null, group));
+        RecruitCommandTargetResolver.resolveGroupTargets(player, this.uuid, this.group, 100D)
+                .forEach((recruit) -> CommandEvents.onMountButton(player.getUUID(), recruit, null, group));
     }
 
     public MessageBackToMountEntity fromBytes(FriendlyByteBuf buf) {

--- a/src/main/java/com/talhanation/recruits/network/MessageClearTarget.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageClearTarget.java
@@ -31,11 +31,9 @@ public class MessageClearTarget implements Message<MessageClearTarget> {
 
     public void executeServerSide(NetworkEvent.Context context){
         ServerPlayer player = Objects.requireNonNull(context.getSender());
-        List<AbstractRecruitEntity> list = player.getCommandSenderWorld().getEntitiesOfClass(
-                AbstractRecruitEntity.class,
-                context.getSender().getBoundingBox().inflate(100));
+        List<AbstractRecruitEntity> list = RecruitCommandTargetResolver.resolveGroupTargets(player, this.uuid, this.group, 100D);
         for (AbstractRecruitEntity recruits : list) {
-            CommandEvents.onClearTargetButton(uuid, recruits, group);
+            CommandEvents.onClearTargetButton(player.getUUID(), recruits, group);
         }
     }
     public MessageClearTarget fromBytes(FriendlyByteBuf buf) {
@@ -50,4 +48,3 @@ public class MessageClearTarget implements Message<MessageClearTarget> {
     }
 
 }
-

--- a/src/main/java/com/talhanation/recruits/network/MessageClearUpkeep.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageClearUpkeep.java
@@ -1,9 +1,9 @@
 package com.talhanation.recruits.network;
 
 import com.talhanation.recruits.CommandEvents;
-import com.talhanation.recruits.entities.AbstractRecruitEntity;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.network.NetworkEvent;
 
@@ -28,12 +28,9 @@ public class MessageClearUpkeep implements Message<MessageClearUpkeep> {
     }
 
     public void executeServerSide(NetworkEvent.Context context) {
-        Objects.requireNonNull(context.getSender()).getCommandSenderWorld().getEntitiesOfClass(
-                AbstractRecruitEntity.class,
-                context.getSender().getBoundingBox().inflate(100)
-        ).forEach(
-                (recruit) -> CommandEvents.onClearUpkeepButton(uuid, recruit, group)
-        );
+        ServerPlayer player = Objects.requireNonNull(context.getSender());
+        RecruitCommandTargetResolver.resolveGroupTargets(player, this.uuid, this.group, 100D)
+                .forEach((recruit) -> CommandEvents.onClearUpkeepButton(player.getUUID(), recruit, group));
     }
 
     public MessageClearUpkeep fromBytes(FriendlyByteBuf buf) {
@@ -47,4 +44,3 @@ public class MessageClearUpkeep implements Message<MessageClearUpkeep> {
         buf.writeUUID(group);
     }
 }
-

--- a/src/main/java/com/talhanation/recruits/network/MessageDismount.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageDismount.java
@@ -1,7 +1,6 @@
 package com.talhanation.recruits.network;
 
 import com.talhanation.recruits.CommandEvents;
-import com.talhanation.recruits.entities.AbstractRecruitEntity;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerPlayer;
@@ -31,10 +30,8 @@ public class MessageDismount implements Message<MessageDismount> {
 
     public void executeServerSide(NetworkEvent.Context context){
         ServerPlayer player = Objects.requireNonNull(context.getSender());
-        player.getCommandSenderWorld().getEntitiesOfClass(
-                AbstractRecruitEntity.class,
-                context.getSender().getBoundingBox().inflate(100)
-        ).forEach((recruit) -> CommandEvents.onDismountButton(uuid, recruit, group));
+        RecruitCommandTargetResolver.resolveGroupTargets(player, this.uuid, this.group, 100D)
+                .forEach((recruit) -> CommandEvents.onDismountButton(player.getUUID(), recruit, group));
     }
     public MessageDismount fromBytes(FriendlyByteBuf buf) {
         this.uuid = buf.readUUID();

--- a/src/main/java/com/talhanation/recruits/network/MessageFormationFollowMovement.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageFormationFollowMovement.java
@@ -4,6 +4,7 @@ import com.talhanation.recruits.CommandEvents;
 import com.talhanation.recruits.entities.AbstractRecruitEntity;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.network.NetworkEvent;
 
@@ -32,10 +33,10 @@ public class MessageFormationFollowMovement implements Message<MessageFormationF
     }
 
     public void executeServerSide(NetworkEvent.Context context){
-        List<AbstractRecruitEntity> list = Objects.requireNonNull(context.getSender()).getCommandSenderWorld().getEntitiesOfClass(AbstractRecruitEntity.class, context.getSender().getBoundingBox().inflate(100));
-        list.removeIf(recruit -> !recruit.isEffectedByCommand(this.player_uuid, this.group));
+        ServerPlayer player = Objects.requireNonNull(context.getSender());
+        List<AbstractRecruitEntity> list = RecruitCommandTargetResolver.resolveGroupTargets(player, this.player_uuid, this.group, 100D);
 
-        CommandEvents.applyFormation(formation, list, context.getSender(), context.getSender().position());
+        CommandEvents.applyFormation(formation, list, player, player.position());
     }
 
     public MessageFormationFollowMovement fromBytes(FriendlyByteBuf buf) {

--- a/src/main/java/com/talhanation/recruits/network/MessageMountEntity.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageMountEntity.java
@@ -4,7 +4,6 @@ import com.talhanation.recruits.CommandEvents;
 import com.talhanation.recruits.compat.siegeweapons.SiegeWeapon;
 import com.talhanation.recruits.compat.smallships.SmallShips;
 import com.talhanation.recruits.config.RecruitsServerConfig;
-import com.talhanation.recruits.entities.AbstractRecruitEntity;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerPlayer;
@@ -46,11 +45,8 @@ public class MessageMountEntity implements Message<MessageMountEntity> {
         );
         if (entityList.isEmpty()) return;
 
-        player.getCommandSenderWorld().getEntitiesOfClass(
-                AbstractRecruitEntity.class,
-                player.getBoundingBox().inflate(100),
-                (recruit) -> recruit.isEffectedByCommand(uuid, group)
-        ).forEach((recruit) -> CommandEvents.onMountButton(uuid, recruit, target, group));
+        RecruitCommandTargetResolver.resolveGroupTargets(player, this.uuid, this.group, 100D)
+                .forEach((recruit) -> CommandEvents.onMountButton(player.getUUID(), recruit, target, group));
     }
 
     public MessageMountEntity fromBytes(FriendlyByteBuf buf) {

--- a/src/main/java/com/talhanation/recruits/network/MessageProtectEntity.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageProtectEntity.java
@@ -1,7 +1,6 @@
 package com.talhanation.recruits.network;
 
 import com.talhanation.recruits.CommandEvents;
-import com.talhanation.recruits.entities.AbstractRecruitEntity;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerPlayer;
@@ -34,10 +33,8 @@ public class MessageProtectEntity implements Message<MessageProtectEntity> {
 
     public void executeServerSide(NetworkEvent.Context context){
         ServerPlayer player = Objects.requireNonNull(context.getSender());
-        player.getCommandSenderWorld().getEntitiesOfClass(
-                AbstractRecruitEntity.class,
-                player.getBoundingBox().inflate(100)
-        ).forEach((recruit) -> CommandEvents.onProtectButton(uuid, recruit, target, group));
+        RecruitCommandTargetResolver.resolveGroupTargets(player, this.uuid, this.group, 100D)
+                .forEach((recruit) -> CommandEvents.onProtectButton(player.getUUID(), recruit, target, group));
     }
     public MessageProtectEntity fromBytes(FriendlyByteBuf buf) {
         this.uuid = buf.readUUID();

--- a/src/main/java/com/talhanation/recruits/network/MessageRangedFire.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageRangedFire.java
@@ -32,10 +32,10 @@ public class MessageRangedFire implements Message<MessageRangedFire> {
     }
 
     public void executeServerSide(NetworkEvent.Context context) {
-        ServerPlayer serverPlayer = context.getSender();
-        List<AbstractRecruitEntity> list = Objects.requireNonNull(context.getSender()).getCommandSenderWorld().getEntitiesOfClass(AbstractRecruitEntity.class, context.getSender().getBoundingBox().inflate(100));
+        ServerPlayer serverPlayer = Objects.requireNonNull(context.getSender());
+        List<AbstractRecruitEntity> list = RecruitCommandTargetResolver.resolveGroupTargets(serverPlayer, this.player, this.group, 100D);
         for (AbstractRecruitEntity recruits : list) {
-                CommandEvents.onRangedFireCommand(serverPlayer, this.player, recruits, group, should);
+            CommandEvents.onRangedFireCommand(serverPlayer, serverPlayer.getUUID(), recruits, group, should);
         }
     }
     public MessageRangedFire fromBytes(FriendlyByteBuf buf) {

--- a/src/main/java/com/talhanation/recruits/network/MessageRest.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageRest.java
@@ -32,10 +32,10 @@ public class MessageRest implements Message<MessageRest> {
     }
 
     public void executeServerSide(NetworkEvent.Context context) {
-        ServerPlayer serverPlayer = context.getSender();
-        List<AbstractRecruitEntity> list = Objects.requireNonNull(context.getSender()).getCommandSenderWorld().getEntitiesOfClass(AbstractRecruitEntity.class, context.getSender().getBoundingBox().inflate(100));
+        ServerPlayer serverPlayer = Objects.requireNonNull(context.getSender());
+        List<AbstractRecruitEntity> list = RecruitCommandTargetResolver.resolveGroupTargets(serverPlayer, this.player, this.group, 100D);
         for (AbstractRecruitEntity recruits : list) {
-                CommandEvents.onRestCommand(serverPlayer, this.player, recruits, group, should);
+            CommandEvents.onRestCommand(serverPlayer, serverPlayer.getUUID(), recruits, group, should);
         }
     }
     public MessageRest fromBytes(FriendlyByteBuf buf) {

--- a/src/main/java/com/talhanation/recruits/network/MessageSaveFormationFollowMovement.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageSaveFormationFollowMovement.java
@@ -1,10 +1,12 @@
 package com.talhanation.recruits.network;
 
 import com.talhanation.recruits.CommandEvents;
+import com.talhanation.recruits.command.RecruitCommandAuthority;
 import com.talhanation.recruits.world.RecruitsGroup;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.network.NetworkEvent;
 
@@ -32,8 +34,12 @@ public class MessageSaveFormationFollowMovement implements Message<MessageSaveFo
     }
 
     public void executeServerSide(NetworkEvent.Context context){
-        CommandEvents.saveFormation(context.getSender(), formation);
-        CommandEvents.saveUUIDList(context.getSender(), "ActiveGroups", RecruitsGroup.uuidListFromNbt(groups));
+        ServerPlayer player = context.getSender();
+        if (player == null || !player.getUUID().equals(this.player_uuid)) return;
+        List<UUID> requestedGroups = RecruitsGroup.uuidListFromNbt(groups);
+        requestedGroups.removeIf(groupUuid -> !RecruitCommandAuthority.ownsGroup(player, groupUuid));
+        CommandEvents.saveFormation(player, formation);
+        CommandEvents.saveUUIDList(player, "ActiveGroups", requestedGroups);
     }
 
     public MessageSaveFormationFollowMovement fromBytes(FriendlyByteBuf buf) {

--- a/src/main/java/com/talhanation/recruits/network/MessageSetTargetPrio.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageSetTargetPrio.java
@@ -1,13 +1,12 @@
 package com.talhanation.recruits.network;
 
-import com.talhanation.recruits.entities.AbstractRecruitEntity;
 import com.talhanation.recruits.entities.IHasTargetPriority;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.network.NetworkEvent;
 
-import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -28,15 +27,11 @@ public class MessageSetTargetPrio implements Message<MessageSetTargetPrio> {
     }
 
     public void executeServerSide(NetworkEvent.Context context){
-        List<AbstractRecruitEntity> list = Objects.requireNonNull(context.getSender()).getCommandSenderWorld().getEntitiesOfClass(AbstractRecruitEntity.class, context.getSender().getBoundingBox().inflate(16D));
-        for (AbstractRecruitEntity recruitEntity : list){
-
-            if (recruitEntity.getUUID().equals(this.recruit) && recruitEntity instanceof IHasTargetPriority specialRecruit){
-
-                specialRecruit.setTargetPriority(IHasTargetPriority.TargetPriority.fromIndex(state));
-                break;
-            }
-        }
+        ServerPlayer player = Objects.requireNonNull(context.getSender());
+        RecruitCommandTargetResolver.resolveOwnedRecruit(player, this.recruit, 16D)
+                .filter(IHasTargetPriority.class::isInstance)
+                .map(IHasTargetPriority.class::cast)
+                .ifPresent(specialRecruit -> specialRecruit.setTargetPriority(IHasTargetPriority.TargetPriority.fromIndex(state)));
     }
     public MessageSetTargetPrio fromBytes(FriendlyByteBuf buf) {
         this.recruit = buf.readUUID();

--- a/src/main/java/com/talhanation/recruits/network/MessageShields.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageShields.java
@@ -1,7 +1,6 @@
 package com.talhanation.recruits.network;
 
 import com.talhanation.recruits.CommandEvents;
-import com.talhanation.recruits.entities.AbstractRecruitEntity;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerPlayer;
@@ -32,13 +31,10 @@ public class MessageShields implements Message<MessageShields> {
 
     public void executeServerSide(NetworkEvent.Context context) {
         ServerPlayer player = Objects.requireNonNull(context.getSender());
-        player.getCommandSenderWorld().getEntitiesOfClass(
-                AbstractRecruitEntity.class,
-                context.getSender().getBoundingBox().inflate(100),
-                (recruit) -> recruit.isEffectedByCommand(this.player, group)
-        ).forEach((recruit) -> CommandEvents.onShieldsCommand(
+        RecruitCommandTargetResolver.resolveGroupTargets(player, this.player, this.group, 100D)
+                .forEach((recruit) -> CommandEvents.onShieldsCommand(
                         player,
-                        this.player,
+                        player.getUUID(),
                         recruit,
                         group,
                         should

--- a/src/main/java/com/talhanation/recruits/network/MessageUpkeepEntity.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageUpkeepEntity.java
@@ -1,8 +1,6 @@
 package com.talhanation.recruits.network;
 
 import com.talhanation.recruits.CommandEvents;
-import com.talhanation.recruits.Main;
-import com.talhanation.recruits.entities.AbstractRecruitEntity;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerPlayer;
@@ -34,10 +32,8 @@ public class MessageUpkeepEntity implements Message<MessageUpkeepEntity> {
 
     public void executeServerSide(NetworkEvent.Context context) {
         ServerPlayer player = Objects.requireNonNull(context.getSender());
-        player.getCommandSenderWorld().getEntitiesOfClass(
-                AbstractRecruitEntity.class,
-                context.getSender().getBoundingBox().inflate(100)
-        ).forEach(recruit -> CommandEvents.onUpkeepCommand(player_uuid, recruit, group, true, target, null));
+        RecruitCommandTargetResolver.resolveGroupTargets(player, this.player_uuid, this.group, 100D)
+                .forEach(recruit -> CommandEvents.onUpkeepCommand(player.getUUID(), recruit, group, true, target, null));
     }
 
     public MessageUpkeepEntity fromBytes(FriendlyByteBuf buf) {

--- a/src/main/java/com/talhanation/recruits/network/MessageUpkeepPos.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageUpkeepPos.java
@@ -1,7 +1,6 @@
 package com.talhanation.recruits.network;
 
 import com.talhanation.recruits.CommandEvents;
-import com.talhanation.recruits.entities.AbstractRecruitEntity;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
@@ -33,11 +32,9 @@ public class MessageUpkeepPos implements Message<MessageUpkeepPos> {
 
     public void executeServerSide(NetworkEvent.Context context) {
         ServerPlayer player = Objects.requireNonNull(context.getSender());
-        player.getCommandSenderWorld().getEntitiesOfClass(
-                AbstractRecruitEntity.class,
-                player.getBoundingBox().inflate(100)
-        ).forEach((recruit) -> CommandEvents.onUpkeepCommand(
-                this.player,
+        RecruitCommandTargetResolver.resolveGroupTargets(player, this.player, this.group, 100D)
+                .forEach((recruit) -> CommandEvents.onUpkeepCommand(
+                player.getUUID(),
                 recruit,
                 group,
                 false,

--- a/src/main/java/com/talhanation/recruits/network/MessageWriteSpawnEgg.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageWriteSpawnEgg.java
@@ -36,9 +36,10 @@ public class MessageWriteSpawnEgg implements Message<MessageWriteSpawnEgg> {
 
     public void executeServerSide(NetworkEvent.Context context) {
         ServerPlayer player = Objects.requireNonNull(context.getSender());
-        player.getCommandSenderWorld().getEntitiesOfClass(AbstractRecruitEntity.class, context.getSender().getBoundingBox().inflate(64.0D),
-                (recruit) -> recruit.getUUID().equals(this.recruit)
-        ).forEach((recruitEntity) -> {
+        if (!player.isCreative() && !player.hasPermissions(2)) {
+            return;
+        }
+        RecruitCommandTargetResolver.resolveOwnedRecruit(player, this.recruit, 64.0D).ifPresent((recruitEntity) -> {
             EntityType<?> type = recruitEntity.getType();
             ItemStack itemStack = this.getItemStack(type);
 


### PR DESCRIPTION
## Summary
- Routes remaining group-wide recruit action packets through server-resolved command targets from the command authority branch.
- Hardens ranged fire, shields, rest, clear target/upkeep, protect, upkeep, mount/dismount, and formation-follow persistence against client-supplied sender/group UUID spoofing.
- Preserves owner transfer and faction-leader takeover behavior while adding server authority checks; gates spawn-egg writing to creative/admin senders.

## Verification
- `source ~/.sdkman/bin/sdkman-init.sh && ./gradlew compileJava`
- code-simplifier cleanup pass completed; post-cleanup compile passed.
- code-reviewer findings resolved: faction takeover preserved, spawn egg minting gated server-side.

## Stack
- Base branch: `feature/command-pipeline-authority` / PR #62.
- This PR should be reviewed after or alongside PR #62.