### PR TITLE
Harden recruit lifecycle authority

### DIFF
--- a/src/main/java/com/talhanation/recruits/CommandEvents.java
+++ b/src/main/java/com/talhanation/recruits/CommandEvents.java
@@ -593,8 +593,11 @@ public class CommandEvents {
     }
 
     public static boolean handleRecruiting(Player player, RecruitsGroup group, AbstractRecruitEntity recruit, boolean message){
+        return handleRecruiting(player, group, recruit, message, recruit.getCost());
+    }
+
+    public static boolean handleRecruiting(Player player, RecruitsGroup group, AbstractRecruitEntity recruit, boolean message, int price){
         String name = recruit.getName().getString() + ": ";
-        int sollPrice = recruit.getCost();
         Inventory playerInv = player.getInventory();
         int playerEmeralds = 0;
 
@@ -614,16 +617,16 @@ public class CommandEvents {
             }
         }
 
-        boolean playerCanPay = playerEmeralds >= sollPrice;
+        boolean playerCanPay = playerEmeralds >= price;
 
         if (playerCanPay || player.isCreative()){
             if(recruit.hire(player, group, message)) {
                 //give player tradeGood
                 //remove playerEmeralds ->add left
                 //
-                playerEmeralds = playerEmeralds - sollPrice;
+                playerEmeralds = playerEmeralds - price;
 
-                //merchantEmeralds = merchantEmeralds + sollPrice;
+                //merchantEmeralds = merchantEmeralds + price;
 
                 //remove playerEmeralds
                 for (int i = 0; i < playerInv.getContainerSize(); i++) {
@@ -654,7 +657,7 @@ public class CommandEvents {
             }
         }
         else
-            player.sendSystemMessage(TEXT_HIRE_COSTS(name, sollPrice, currency));
+            player.sendSystemMessage(TEXT_HIRE_COSTS(name, price, currency));
 
         return false;
     }

--- a/src/main/java/com/talhanation/recruits/VillagerEvents.java
+++ b/src/main/java/com/talhanation/recruits/VillagerEvents.java
@@ -230,9 +230,9 @@ public class VillagerEvents {
         }
     }
 
-    public static void createHiredRecruitFromVillager(ServerLevel serverLevel, Villager villager, EntityType<? extends AbstractRecruitEntity> recruitType, Player player, RecruitsGroup group){
+    public static boolean createHiredRecruitFromVillager(ServerLevel serverLevel, Villager villager, EntityType<? extends AbstractRecruitEntity> recruitType, Player player, RecruitsGroup group, int price){
         AbstractRecruitEntity abstractRecruit = recruitType.create(villager.getCommandSenderWorld());
-        if(abstractRecruit == null) return;
+        if(abstractRecruit == null) return false;
 
         abstractRecruit.initSpawn();
 
@@ -240,7 +240,7 @@ public class VillagerEvents {
 
         if(name != null && !name.getString().isEmpty()) abstractRecruit.setCustomName(name);
 
-        if (CommandEvents.handleRecruiting(player, group, abstractRecruit, false)) {
+        if (CommandEvents.handleRecruiting(player, group, abstractRecruit, false, price)) {
             abstractRecruit.copyPosition(villager);
 
             abstractRecruit.setFollowState(1);
@@ -264,16 +264,18 @@ public class VillagerEvents {
             villager.releasePoi(MemoryModuleType.HOME);
             villager.releasePoi(MemoryModuleType.MEETING_POINT);
             villager.discard();
+            return true;
         }
+        return false;
     }
 
-    public static void spawnHiredRecruit(ServerLevel serverLevel, EntityType<? extends AbstractRecruitEntity> recruitType, Player player, RecruitsGroup group){
+    public static boolean spawnHiredRecruit(ServerLevel serverLevel, EntityType<? extends AbstractRecruitEntity> recruitType, Player player, RecruitsGroup group, int price){
         AbstractRecruitEntity abstractRecruit = recruitType.create(player.getCommandSenderWorld());
-        if(abstractRecruit == null) return;
+        if(abstractRecruit == null) return false;
 
         abstractRecruit.initSpawn();
 
-        if (CommandEvents.handleRecruiting(player, group, abstractRecruit, false)) {
+        if (CommandEvents.handleRecruiting(player, group, abstractRecruit, false, price)) {
             abstractRecruit.copyPosition(player);
 
             abstractRecruit.setFollowState(1);
@@ -287,7 +289,9 @@ public class VillagerEvents {
                 }
                 companion.applyRecruitValues(abstractRecruit);
             }
+            return true;
         }
+        return false;
     }
 
     @SubscribeEvent

--- a/src/main/java/com/talhanation/recruits/entities/VillagerNobleEntity.java
+++ b/src/main/java/com/talhanation/recruits/entities/VillagerNobleEntity.java
@@ -50,6 +50,7 @@ public class VillagerNobleEntity extends AbstractRecruitEntity implements ICanTr
             (!item.hasPickUpDelay() && item.isAlive() && getInventory().canAddItem(item.getItem()) && this.wantsToPickUp(item.getItem()));
     private int restoreTimer;
     public boolean isTrading;
+    private UUID tradingPlayer;
     public boolean needsNewTrades;
     public int restoreTimeLongTime;
 
@@ -192,6 +193,7 @@ public class VillagerNobleEntity extends AbstractRecruitEntity implements ICanTr
     }
 
     public void openTradeGUI(Player player){
+        this.tradingPlayer = player.getUUID();
         this.isTrading(true);
         String stringID = player.getTeam() != null ? player.getTeam().getName() : "";
 
@@ -371,6 +373,13 @@ public class VillagerNobleEntity extends AbstractRecruitEntity implements ICanTr
 
     public void isTrading(boolean trading) {
         this.isTrading = trading;
+        if (!trading) {
+            this.tradingPlayer = null;
+        }
+    }
+
+    public boolean isTradingWith(Player player) {
+        return player != null && player.getUUID().equals(this.tradingPlayer);
     }
 
     protected void addParticlesAroundSelf(ParticleOptions p_35288_) {
@@ -387,13 +396,3 @@ public class VillagerNobleEntity extends AbstractRecruitEntity implements ICanTr
         return this.getTeam() != null ? this.getTeam().getName() : "";
     }
 }
-
-
-
-
-
-
-
-
-
-

--- a/src/main/java/com/talhanation/recruits/network/MessageDisband.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageDisband.java
@@ -1,6 +1,5 @@
 package com.talhanation.recruits.network;
 
-import com.talhanation.recruits.entities.AbstractRecruitEntity;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerPlayer;
@@ -29,11 +28,8 @@ public class MessageDisband implements Message<MessageDisband> {
 
     public void executeServerSide(NetworkEvent.Context context) {
         ServerPlayer player = Objects.requireNonNull(context.getSender());
-        player.getCommandSenderWorld().getEntitiesOfClass(
-                AbstractRecruitEntity.class,
-                player.getBoundingBox().inflate(16D),
-                (recruit) -> recruit.getUUID().equals(this.recruit)
-        ).forEach((recruit) -> recruit.disband(context.getSender(), keepTeam, true));
+        RecruitCommandTargetResolver.resolveOwnedRecruit(player, this.recruit, 16D, false)
+                .ifPresent((recruit) -> recruit.disband(player, keepTeam, true));
     }
 
     public MessageDisband fromBytes(FriendlyByteBuf buf) {

--- a/src/main/java/com/talhanation/recruits/network/MessageDoPayment.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageDoPayment.java
@@ -33,9 +33,13 @@ public class MessageDoPayment implements Message<MessageDoPayment> {
 
         if(!serverPlayer.getUUID().equals(uuid)) return;
 
+        if (this.amount <= 0) return;
+
         if(serverPlayer.isCreative() && serverPlayer.hasPermissions(2)){
             return;
         }
+
+        if (!FactionEvents.playerHasEnoughEmeralds(serverPlayer, this.amount)) return;
 
         FactionEvents.doPayment(serverPlayer, this.amount);
     }

--- a/src/main/java/com/talhanation/recruits/network/MessageHire.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageHire.java
@@ -1,7 +1,7 @@
 package com.talhanation.recruits.network;
 
 import com.talhanation.recruits.CommandEvents;
-import com.talhanation.recruits.RecruitEvents;
+import com.talhanation.recruits.command.RecruitCommandAuthority;
 import com.talhanation.recruits.entities.AbstractRecruitEntity;
 import com.talhanation.recruits.world.RecruitsGroup;
 import de.maxhenkel.corelib.net.Message;
@@ -34,11 +34,17 @@ public class MessageHire implements Message<MessageHire> {
 
     public void executeServerSide(NetworkEvent.Context context) {
         ServerPlayer player = Objects.requireNonNull(context.getSender());
-        RecruitsGroup group = RecruitEvents.recruitsGroupsManager.getGroup(groupUUID);
+        if (!player.getUUID().equals(this.player)) {
+            return;
+        }
+        RecruitsGroup group = RecruitCommandAuthority.ownedGroup(player, groupUUID);
+        if (group == null) {
+            return;
+        }
         player.getCommandSenderWorld().getEntitiesOfClass(
                 AbstractRecruitEntity.class,
                 player.getBoundingBox().inflate(16.0D),
-                v -> v.getUUID().equals(this.recruit) && v.isAlive()
+                v -> v.getUUID().equals(this.recruit) && v.isAlive() && !v.isOwned() && v.canBeHired()
         ).forEach(recruit -> CommandEvents.handleRecruiting(player, group, recruit, true));
     }
 

--- a/src/main/java/com/talhanation/recruits/network/MessageHireFromNobleVillager.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageHireFromNobleVillager.java
@@ -3,6 +3,8 @@ package com.talhanation.recruits.network;
 import com.talhanation.recruits.Main;
 import com.talhanation.recruits.RecruitEvents;
 import com.talhanation.recruits.VillagerEvents;
+import com.talhanation.recruits.command.RecruitCommandAuthority;
+import com.talhanation.recruits.config.RecruitsServerConfig;
 import com.talhanation.recruits.entities.AbstractRecruitEntity;
 import com.talhanation.recruits.entities.VillagerNobleEntity;
 import com.talhanation.recruits.world.RecruitsGroup;
@@ -14,6 +16,7 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.npc.Villager;
+import net.minecraft.world.entity.npc.VillagerProfession;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.network.NetworkEvent;
@@ -62,27 +65,57 @@ public class MessageHireFromNobleVillager implements Message<MessageHireFromNobl
                 VillagerNobleEntity.class,
                 player.getBoundingBox().inflate(32.0D),
                 noble -> noble.getUUID().equals(this.nobleUUID) && noble.isAlive()
-        ).stream().findAny().get();
+        ).stream().findFirst().orElse(null);
 
-        if(closing){
-            villagerNoble.isTrading(false);
+        if (villagerNoble == null) {
             return;
         }
 
-        RecruitsGroup group = RecruitEvents.recruitsGroupsManager.getGroup(groupUUID);
+        if(closing){
+            if (villagerNoble.isTradingWith(player)) {
+                villagerNoble.isTrading(false);
+            }
+            return;
+        }
 
-        if(this.needsVillager){
-            player.getCommandSenderWorld().getEntitiesOfClass(
+        if (!villagerNoble.isTradingWith(player)) {
+            return;
+        }
+
+        RecruitsGroup group = RecruitCommandAuthority.ownedGroup(player, groupUUID);
+        if (group == null) {
+            return;
+        }
+
+        RecruitsHireTrade trade = getAvailableTrade(villagerNoble);
+        if (trade == null) {
+            return;
+        }
+
+        boolean requiresVillager = RecruitsServerConfig.NobleVillagerNeedsVillagers.get();
+        boolean hired;
+        if (requiresVillager) {
+            var eligibleVillagers = player.getCommandSenderWorld().getEntitiesOfClass(
                     Villager.class,
                     player.getBoundingBox().inflate(32.0D),
-                    villager -> villager.getUUID().equals(this.villagerUUID) && villager.isAlive()
-            ).forEach(villager -> this.createRecruit(serverLevel, villager, villagerNoble, player, group));
+                    MessageHireFromNobleVillager::isEligibleHireVillager
+            );
+            if (eligibleVillagers.size() <= 2) {
+                return;
+            }
+            hired = eligibleVillagers.stream()
+                    .filter(villager -> villager.getUUID().equals(this.villagerUUID))
+                    .findFirst()
+                    .map(villager -> this.createRecruit(serverLevel, villager, player, group, trade.cost))
+                    .orElse(false);
         }
-        else{
-            String string = resource.toString();
-            Optional<EntityType<?>> optionalType = EntityType.byString(string);
-            optionalType.ifPresent(type -> VillagerEvents.spawnHiredRecruit(serverLevel, (EntityType<? extends AbstractRecruitEntity>) type, player, group));
+        else {
+            hired = getRecruitType()
+                    .map(type -> VillagerEvents.spawnHiredRecruit(serverLevel, type, player, group, trade.cost))
+                    .orElse(false);
+        }
 
+        if (hired) {
             villagerNoble.doTrade(resource);
         }
 
@@ -90,15 +123,31 @@ public class MessageHireFromNobleVillager implements Message<MessageHireFromNobl
         boolean canHire = RecruitEvents.recruitsPlayerUnitManager.canPlayerRecruit(stringID, player.getUUID());
         Main.SIMPLE_CHANNEL.send(PacketDistributor.PLAYER.with(()-> player), new MessageToClientUpdateHireState(canHire));
     }
-    public void createRecruit(ServerLevel serverLevel, Villager villager, VillagerNobleEntity villagerNoble, Player player, RecruitsGroup group){
-        String string = resource.toString();
-        Optional<EntityType<?>> optionalType = EntityType.byString(string);
 
-        optionalType.ifPresent(type -> {
-            VillagerEvents.createHiredRecruitFromVillager(serverLevel, villager, (EntityType<? extends AbstractRecruitEntity>) type, player, group);
-        });
+    private RecruitsHireTrade getAvailableTrade(VillagerNobleEntity villagerNoble) {
+        for (RecruitsHireTrade trade : villagerNoble.getTrades()) {
+            if (trade != null && trade.uses > 0 && trade.resourceLocation.equals(this.resource)) {
+                return trade;
+            }
+        }
+        return null;
+    }
 
-        villagerNoble.doTrade(resource);
+    private static boolean isEligibleHireVillager(Villager villager) {
+        return villager.isAlive()
+                && !villager.isBaby()
+                && villager.getVillagerData().getProfession().equals(VillagerProfession.NONE);
+    }
+
+    private Optional<EntityType<? extends AbstractRecruitEntity>> getRecruitType() {
+        return EntityType.byString(resource.toString())
+                .map(type -> (EntityType<? extends AbstractRecruitEntity>) type);
+    }
+
+    private boolean createRecruit(ServerLevel serverLevel, Villager villager, Player player, RecruitsGroup group, int price) {
+        return getRecruitType()
+                .map(type -> VillagerEvents.createHiredRecruitFromVillager(serverLevel, villager, type, player, group, price))
+                .orElse(false);
     }
 
     public MessageHireFromNobleVillager fromBytes(FriendlyByteBuf buf) {

--- a/src/main/java/com/talhanation/recruits/network/MessageOpenDisbandScreen.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageOpenDisbandScreen.java
@@ -32,10 +32,14 @@ public class MessageOpenDisbandScreen implements Message<MessageOpenDisbandScree
     @Override
     public void executeServerSide(NetworkEvent.Context context) {
         ServerPlayer player = context.getSender();
+        if (player == null) {
+            return;
+        }
         if (!player.getUUID().equals(this.player)) {
             return;
         }
-        FactionEvents.openDisbandingScreen(player, recruit);
+        RecruitCommandTargetResolver.resolveOwnedRecruit(player, this.recruit, 16.0D, false)
+                .ifPresent((recruit) -> FactionEvents.openDisbandingScreen(player, recruit.getUUID()));
     }
 
     @Override

--- a/src/main/java/com/talhanation/recruits/network/MessageOpenPromoteScreen.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageOpenPromoteScreen.java
@@ -1,11 +1,9 @@
 package com.talhanation.recruits.network;
 
 import com.talhanation.recruits.RecruitEvents;
-import com.talhanation.recruits.entities.AbstractRecruitEntity;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.network.NetworkEvent;
@@ -39,11 +37,9 @@ public class MessageOpenPromoteScreen implements Message<MessageOpenPromoteScree
             return;
         }
 
-        player.getCommandSenderWorld().getEntitiesOfClass(
-                AbstractRecruitEntity.class,
-                player.getBoundingBox().inflate(16.0D),
-                v -> v.getUUID().equals(this.recruit) && v.isAlive()
-        ).forEach((recruit) -> RecruitEvents.openPromoteScreen(player, recruit));
+        RecruitCommandTargetResolver.resolveOwnedRecruit(player, this.recruit, 16.0D, false)
+                .filter(MessagePromoteRecruit::canPromote)
+                .ifPresent((recruit) -> RecruitEvents.openPromoteScreen(player, recruit));
     }
 
     @Override

--- a/src/main/java/com/talhanation/recruits/network/MessagePatrolLeaderAddWayPoint.java
+++ b/src/main/java/com/talhanation/recruits/network/MessagePatrolLeaderAddWayPoint.java
@@ -43,11 +43,8 @@ public class MessagePatrolLeaderAddWayPoint implements Message<MessagePatrolLead
 
     public void executeServerSide(NetworkEvent.Context context) {
         ServerPlayer player = Objects.requireNonNull(context.getSender());
-        player.getCommandSenderWorld().getEntitiesOfClass(
-                AbstractLeaderEntity.class,
-                player.getBoundingBox().inflate(100.0D),
-                v -> v.getUUID().equals(this.worker) && v.isAlive()
-        ).forEach((merchant) -> this.addWayPoint(new BlockPos(x, y, z), player, merchant));
+        RecruitCommandTargetResolver.resolveOwnedLeader(player, this.worker, 100.0D)
+                .ifPresent((merchant) -> this.addWayPoint(new BlockPos(x, y, z), player, merchant));
     }
 
     private void addWayPoint(BlockPos pos, Player player, AbstractLeaderEntity leaderEntity) {

--- a/src/main/java/com/talhanation/recruits/network/MessagePatrolLeaderRemoveWayPoint.java
+++ b/src/main/java/com/talhanation/recruits/network/MessagePatrolLeaderRemoveWayPoint.java
@@ -30,11 +30,8 @@ public class MessagePatrolLeaderRemoveWayPoint implements Message<MessagePatrolL
 
     public void executeServerSide(NetworkEvent.Context context) {
         ServerPlayer player = Objects.requireNonNull(context.getSender());
-        player.getCommandSenderWorld().getEntitiesOfClass(
-                AbstractLeaderEntity.class,
-                player.getBoundingBox().inflate(100.0D),
-                v -> v.getUUID().equals(this.worker) && v.isAlive()
-        ).forEach((merchant) -> this.removeLastWayPoint(player, merchant));
+        RecruitCommandTargetResolver.resolveOwnedLeader(player, this.worker, 100.0D)
+                .ifPresent((merchant) -> this.removeLastWayPoint(player, merchant));
     }
 
     private void removeLastWayPoint(ServerPlayer player, AbstractLeaderEntity leaderEntity) {

--- a/src/main/java/com/talhanation/recruits/network/MessagePatrolLeaderSetCycle.java
+++ b/src/main/java/com/talhanation/recruits/network/MessagePatrolLeaderSetCycle.java
@@ -1,6 +1,5 @@
 package com.talhanation.recruits.network;
 
-import com.talhanation.recruits.entities.AbstractLeaderEntity;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerPlayer;
@@ -30,11 +29,8 @@ public class MessagePatrolLeaderSetCycle implements Message<MessagePatrolLeaderS
 
     public void executeServerSide(NetworkEvent.Context context) {
         ServerPlayer player = Objects.requireNonNull(context.getSender());
-        player.getCommandSenderWorld().getEntitiesOfClass(
-                AbstractLeaderEntity.class,
-                player.getBoundingBox().inflate(100.0D),
-                (leader) -> leader.getUUID().equals(this.recruit)
-        ).forEach(leader -> leader.setCycle(this.cycle));
+        RecruitCommandTargetResolver.resolveOwnedLeader(player, this.recruit, 100.0D)
+                .ifPresent(leader -> leader.setCycle(this.cycle));
     }
 
     public MessagePatrolLeaderSetCycle fromBytes(FriendlyByteBuf buf) {

--- a/src/main/java/com/talhanation/recruits/network/MessagePatrolLeaderSetEnemyAction.java
+++ b/src/main/java/com/talhanation/recruits/network/MessagePatrolLeaderSetEnemyAction.java
@@ -28,11 +28,11 @@ public class MessagePatrolLeaderSetEnemyAction implements Message<MessagePatrolL
 
     public void executeServerSide(NetworkEvent.Context context) {
         ServerPlayer player = Objects.requireNonNull(context.getSender());
-        player.getCommandSenderWorld().getEntitiesOfClass(
-                AbstractLeaderEntity.class,
-                player.getBoundingBox().inflate(100.0D),
-                leader -> leader.getUUID().equals(this.recruit) && leader.isAlive()
-        ).forEach(leader -> leader.setEnemyAction(this.action));
+        if (this.action < AbstractLeaderEntity.EnemyAction.CHARGE.getIndex() || this.action > AbstractLeaderEntity.EnemyAction.KEEP_PATROLLING.getIndex()) {
+            return;
+        }
+        RecruitCommandTargetResolver.resolveOwnedLeader(player, this.recruit, 100.0D)
+                .ifPresent(leader -> leader.setEnemyAction(AbstractLeaderEntity.EnemyAction.fromIndex(this.action).getIndex()));
     }
 
     public MessagePatrolLeaderSetEnemyAction fromBytes(FriendlyByteBuf buf) {

--- a/src/main/java/com/talhanation/recruits/network/MessagePatrolLeaderSetInfoMode.java
+++ b/src/main/java/com/talhanation/recruits/network/MessagePatrolLeaderSetInfoMode.java
@@ -28,11 +28,11 @@ public class MessagePatrolLeaderSetInfoMode implements Message<MessagePatrolLead
 
     public void executeServerSide(NetworkEvent.Context context) {
         ServerPlayer player = Objects.requireNonNull(context.getSender());
-        player.getCommandSenderWorld().getEntitiesOfClass(
-                AbstractLeaderEntity.class,
-                player.getBoundingBox().inflate(16.0D),
-                v -> v.getUUID().equals(this.recruit) && v.isAlive()
-        ).forEach((leader) -> leader.setInfoMode(state));
+        if (state < AbstractLeaderEntity.InfoMode.ALL.getIndex() || state > AbstractLeaderEntity.InfoMode.HOSTILE.getIndex()) {
+            return;
+        }
+        RecruitCommandTargetResolver.resolveOwnedLeader(player, this.recruit, 16.0D)
+                .ifPresent((leader) -> leader.setInfoMode(state));
     }
 
     public MessagePatrolLeaderSetInfoMode fromBytes(FriendlyByteBuf buf) {

--- a/src/main/java/com/talhanation/recruits/network/MessagePatrolLeaderSetPatrolState.java
+++ b/src/main/java/com/talhanation/recruits/network/MessagePatrolLeaderSetPatrolState.java
@@ -28,14 +28,20 @@ public class MessagePatrolLeaderSetPatrolState implements Message<MessagePatrolL
 
     public void executeServerSide(NetworkEvent.Context context) {
         ServerPlayer player = Objects.requireNonNull(context.getSender());
-        player.getCommandSenderWorld().getEntitiesOfClass(
-                AbstractLeaderEntity.class,
-                player.getBoundingBox().inflate(64.0D),
-                v -> v.getUUID().equals(this.recruit) && v.isAlive()
-        ).forEach(this::setState);
+        if (!isValidPatrolState(this.state)) {
+            return;
+        }
+        RecruitCommandTargetResolver.resolveOwnedLeader(player, this.recruit, 64.0D)
+                .ifPresent(this::setState);
     }
 
-    public void setState(AbstractLeaderEntity leader) {
+    private static boolean isValidPatrolState(byte state) {
+        return state == AbstractLeaderEntity.State.PATROLLING.getIndex()
+                || state == AbstractLeaderEntity.State.PAUSED.getIndex()
+                || state == AbstractLeaderEntity.State.STOPPED.getIndex();
+    }
+
+    private void setState(AbstractLeaderEntity leader) {
         AbstractLeaderEntity.State leaderState = AbstractLeaderEntity.State.fromIndex(state);
         switch (leaderState) {
             case PATROLLING -> leader.setFollowState(0);

--- a/src/main/java/com/talhanation/recruits/network/MessagePatrolLeaderSetPatrollingSpeed.java
+++ b/src/main/java/com/talhanation/recruits/network/MessagePatrolLeaderSetPatrollingSpeed.java
@@ -28,11 +28,11 @@ public class MessagePatrolLeaderSetPatrollingSpeed implements Message<MessagePat
 
     public void executeServerSide(NetworkEvent.Context context) {
         ServerPlayer player = Objects.requireNonNull(context.getSender());
-        player.getCommandSenderWorld().getEntitiesOfClass(
-                AbstractLeaderEntity.class,
-                context.getSender().getBoundingBox().inflate(100.0D),
-                recruit -> recruit.getUUID().equals(this.recruit)
-        ).forEach(leader -> leader.setPatrolSpeed(this.speed));
+        if (this.speed < AbstractLeaderEntity.PatrolSpeed.SLOW.getIndex() || this.speed > AbstractLeaderEntity.PatrolSpeed.FAST.getIndex()) {
+            return;
+        }
+        RecruitCommandTargetResolver.resolveOwnedLeader(player, this.recruit, 100.0D)
+                .ifPresent(leader -> leader.setPatrolSpeed(AbstractLeaderEntity.PatrolSpeed.fromIndex(this.speed).getIndex()));
     }
 
     public MessagePatrolLeaderSetPatrollingSpeed fromBytes(FriendlyByteBuf buf) {

--- a/src/main/java/com/talhanation/recruits/network/MessagePatrolLeaderSetRoute.java
+++ b/src/main/java/com/talhanation/recruits/network/MessagePatrolLeaderSetRoute.java
@@ -1,6 +1,5 @@
 package com.talhanation.recruits.network;
 
-import com.talhanation.recruits.entities.AbstractLeaderEntity;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
@@ -52,11 +51,7 @@ public class MessagePatrolLeaderSetRoute implements Message<MessagePatrolLeaderS
     @Override
     public void executeServerSide(NetworkEvent.Context context) {
         ServerPlayer player = Objects.requireNonNull(context.getSender());
-        player.getCommandSenderWorld().getEntitiesOfClass(
-                AbstractLeaderEntity.class,
-                player.getBoundingBox().inflate(64.0D),
-                leader -> leader.getUUID().equals(this.recruit) && leader.isAlive()
-        ).forEach(leader -> {
+        RecruitCommandTargetResolver.resolveOwnedLeader(player, this.recruit, 64.0D).ifPresent(leader -> {
             if (routeId != null) {
                 leader.setRouteID(routeId);
             } else {

--- a/src/main/java/com/talhanation/recruits/network/MessagePatrolLeaderSetWaitTime.java
+++ b/src/main/java/com/talhanation/recruits/network/MessagePatrolLeaderSetWaitTime.java
@@ -1,6 +1,5 @@
 package com.talhanation.recruits.network;
 
-import com.talhanation.recruits.entities.AbstractLeaderEntity;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerPlayer;
@@ -30,11 +29,8 @@ public class MessagePatrolLeaderSetWaitTime implements Message<MessagePatrolLead
 
     public void executeServerSide(NetworkEvent.Context context) {
         ServerPlayer player = Objects.requireNonNull(context.getSender());
-        player.getCommandSenderWorld().getEntitiesOfClass(
-                AbstractLeaderEntity.class,
-                player.getBoundingBox().inflate(100.0D),
-                (leader) -> leader.getUUID().equals(this.recruit)
-        ).forEach((leader) -> leader.setWaitTimeInMin(this.time));
+        RecruitCommandTargetResolver.resolveOwnedLeader(player, this.recruit, 100.0D)
+                .ifPresent((leader) -> leader.setWaitTimeInMin(Math.max(0, this.time)));
     }
 
     public MessagePatrolLeaderSetWaitTime fromBytes(FriendlyByteBuf buf) {

--- a/src/main/java/com/talhanation/recruits/network/MessagePromoteRecruit.java
+++ b/src/main/java/com/talhanation/recruits/network/MessagePromoteRecruit.java
@@ -1,13 +1,15 @@
 package com.talhanation.recruits.network;
 
+import com.talhanation.recruits.Main;
 import com.talhanation.recruits.RecruitEvents;
+import com.talhanation.recruits.compat.workers.IVillagerWorker;
 import com.talhanation.recruits.entities.AbstractRecruitEntity;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.network.NetworkEvent;
 
-import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -30,12 +32,29 @@ public class MessagePromoteRecruit implements Message<MessagePromoteRecruit> {
     }
 
     public void executeServerSide(NetworkEvent.Context context){
-        Objects.requireNonNull(context.getSender()).getCommandSenderWorld().getEntitiesOfClass(
-                AbstractRecruitEntity.class,
-                context.getSender().getBoundingBox().inflate(16D),
-                livingEntity -> livingEntity.getUUID().equals(this.recruit)
-        ).forEach((recruit) -> RecruitEvents.promoteRecruit(recruit, profession, name, context.getSender()));
+        ServerPlayer player = Objects.requireNonNull(context.getSender());
+        if (!RecruitEvents.entitiesByProfession.containsKey(this.profession)) {
+            return;
+        }
 
+        RecruitCommandTargetResolver.resolveOwnedRecruit(player, this.recruit, 16D, false)
+                .filter((recruit) -> canPromoteTo(recruit, this.profession))
+                .ifPresent((recruit) -> RecruitEvents.promoteRecruit(recruit, profession, name, player));
+    }
+
+    static boolean canPromote(AbstractRecruitEntity recruit) {
+        return recruit.getXpLevel() >= 3 || recruit instanceof IVillagerWorker;
+    }
+
+    static boolean canPromoteTo(AbstractRecruitEntity recruit, int profession) {
+        boolean worker = recruit instanceof IVillagerWorker;
+        return switch (profession) {
+            case 0, 1 -> worker || recruit.getXpLevel() >= 2;
+            case 2 -> (worker || recruit.getXpLevel() >= 3) && Main.isSiegeWeaponsLoaded && Main.isSiegeWeaponsCompatible;
+            case 3 -> (worker || recruit.getXpLevel() >= 5) && Main.isSmallShipsLoaded && Main.isSmallShipsCompatible;
+            case 4 -> worker || recruit.getXpLevel() >= 5;
+            default -> false;
+        };
     }
     public MessagePromoteRecruit fromBytes(FriendlyByteBuf buf) {
         this.recruit = buf.readUUID();

--- a/src/main/java/com/talhanation/recruits/network/MessageRecruitGui.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageRecruitGui.java
@@ -1,10 +1,8 @@
 package com.talhanation.recruits.network;
 
-import com.talhanation.recruits.entities.AbstractRecruitEntity;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.network.NetworkEvent;
@@ -39,11 +37,8 @@ public class MessageRecruitGui implements Message<MessageRecruitGui> {
             return;
         }
 
-        player.getCommandSenderWorld().getEntitiesOfClass(
-                AbstractRecruitEntity.class,
-                player.getBoundingBox().inflate(16.0D),
-                v -> v.getUUID().equals(this.recruit) && v.isAlive()
-        ).forEach(recruit -> recruit.openGUI(player));
+        RecruitCommandTargetResolver.resolveOwnedRecruit(player, this.recruit, 16.0D, false)
+                .ifPresent(recruit -> recruit.openGUI(player));
     }
 
     @Override

--- a/src/main/java/com/talhanation/recruits/network/MessageScoutTask.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageScoutTask.java
@@ -3,10 +3,10 @@ package com.talhanation.recruits.network;
 import com.talhanation.recruits.entities.ScoutEntity;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.network.NetworkEvent;
 
-import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -27,15 +27,14 @@ public class MessageScoutTask implements Message<MessageScoutTask> {
     }
 
     public void executeServerSide(NetworkEvent.Context context){
-        List<ScoutEntity> list = Objects.requireNonNull(context.getSender()).getCommandSenderWorld().getEntitiesOfClass(ScoutEntity.class, context.getSender().getBoundingBox().inflate(16D));
-        for (ScoutEntity scoutEntity : list){
-
-            if (scoutEntity.getUUID().equals(this.recruit)){
-
-                scoutEntity.startTask(ScoutEntity.State.fromIndex(state));
-                break;
-            }
+        ServerPlayer player = Objects.requireNonNull(context.getSender());
+        if (this.state < ScoutEntity.State.IDLE.getIndex() || this.state > ScoutEntity.State.SEARCHING_LOST_RECRUITS.getIndex()) {
+            return;
         }
+        RecruitCommandTargetResolver.resolveOwnedRecruit(player, this.recruit, 16D, false)
+                .filter(ScoutEntity.class::isInstance)
+                .map(ScoutEntity.class::cast)
+                .ifPresent((scout) -> scout.startTask(ScoutEntity.State.fromIndex(state)));
     }
     public MessageScoutTask fromBytes(FriendlyByteBuf buf) {
         this.recruit = buf.readUUID();


### PR DESCRIPTION
## Summary
- Harden hire, disband, promote, recruit GUI, scout, and patrol-leader packets with server-side ownership/session checks.
- Make noble-villager hiring use server-side trade/session/villager validation and authoritative trade cost before consuming uses.
- Preserve existing command/action authority helpers while rejecting malformed enum/payment inputs.

## Verification
- `source "$HOME/.sdkman/bin/sdkman-init.sh" && ./gradlew compileJava`
- code-simplifier pass completed
- code-reviewer pass completed with no findings