### PR TITLE
Harden faction diplomacy authority

### DIFF
--- a/src/main/java/com/talhanation/recruits/network/FactionNetworkAuthority.java
+++ b/src/main/java/com/talhanation/recruits/network/FactionNetworkAuthority.java
@@ -1,0 +1,46 @@
+package com.talhanation.recruits.network;
+
+import com.talhanation.recruits.FactionEvents;
+import com.talhanation.recruits.world.RecruitsFaction;
+import com.talhanation.recruits.world.RecruitsPlayerInfo;
+import net.minecraft.server.level.ServerPlayer;
+
+import javax.annotation.Nullable;
+
+final class FactionNetworkAuthority {
+    static final int MAX_UNIT_COLOR_INDEX = 24;
+
+    private FactionNetworkAuthority() {
+    }
+
+    @Nullable
+    static RecruitsFaction leaderFaction(ServerPlayer player) {
+        if (player == null || player.getTeam() == null) {
+            return null;
+        }
+        RecruitsFaction faction = FactionEvents.recruitsFactionManager.getFactionByStringID(player.getTeam().getName());
+        return faction != null && player.getUUID().equals(faction.getTeamLeaderUUID()) ? faction : null;
+    }
+
+    static boolean isLeaderOf(ServerPlayer player, String factionId) {
+        RecruitsFaction faction = leaderFaction(player);
+        return faction != null && faction.getStringID().equals(factionId);
+    }
+
+    static boolean isMember(RecruitsFaction faction, RecruitsPlayerInfo playerInfo) {
+        return faction != null
+                && playerInfo != null
+                && faction.getMembers().stream().anyMatch(member -> member.getUUID().equals(playerInfo.getUUID()));
+    }
+
+    @Nullable
+    static RecruitsPlayerInfo memberByUuid(RecruitsFaction faction, RecruitsPlayerInfo playerInfo) {
+        if (faction == null || playerInfo == null) {
+            return null;
+        }
+        return faction.getMembers().stream()
+                .filter(member -> member.getUUID().equals(playerInfo.getUUID()))
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/src/main/java/com/talhanation/recruits/network/MessageAnswerMessenger.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageAnswerMessenger.java
@@ -7,7 +7,6 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.network.NetworkEvent;
 
-import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -25,24 +24,28 @@ public class MessageAnswerMessenger implements Message<MessageAnswerMessenger> {
     }
 
     public void executeServerSide(NetworkEvent.Context context){
-        ServerPlayer player = context.getSender();
-        List<MessengerEntity> list = Objects.requireNonNull(context.getSender()).getCommandSenderWorld().getEntitiesOfClass(
+        ServerPlayer player = Objects.requireNonNull(context.getSender());
+        for (MessengerEntity messenger : player.getCommandSenderWorld().getEntitiesOfClass(
                 MessengerEntity.class,
-                context.getSender().getBoundingBox().inflate(16D)
-        );
-        for (MessengerEntity messenger : list){
+                player.getBoundingBox().inflate(16D),
+                messenger -> messenger.getUUID().equals(this.recruit) && canAnswer(player, messenger)
+        )){
+            messenger.teleportWaitTimer = 100;
+            player.sendSystemMessage(messenger.MESSENGER_INFO_ON_MY_WAY());
+            messenger.giveDeliverItem(player);
 
-            if (messenger.getUUID().equals(this.recruit)){
-
-                messenger.teleportWaitTimer = 100;
-                context.getSender().sendSystemMessage(messenger.MESSENGER_INFO_ON_MY_WAY());
-                messenger.giveDeliverItem(player);
-
-                messenger.setMessengerState(MessengerEntity.MessengerState.TELEPORT_BACK);
-            }
+            messenger.setMessengerState(MessengerEntity.MessengerState.TELEPORT_BACK);
+            break;
         }
 
     }
+
+    private static boolean canAnswer(ServerPlayer player, MessengerEntity messenger) {
+        return !messenger.isTreatyMessenger()
+                && messenger.getTargetPlayerInfo() != null
+                && player.getUUID().equals(messenger.getTargetPlayerInfo().getUUID());
+    }
+
     public MessageAnswerMessenger fromBytes(FriendlyByteBuf buf) {
         this.recruit = buf.readUUID();
         return this;

--- a/src/main/java/com/talhanation/recruits/network/MessageAnswerTreaty.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageAnswerTreaty.java
@@ -13,7 +13,6 @@ import net.minecraft.world.scores.Team;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.network.NetworkEvent;
 
-import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -40,23 +39,31 @@ public class MessageAnswerTreaty implements Message<MessageAnswerTreaty> {
         ServerPlayer player = Objects.requireNonNull(context.getSender());
         ServerLevel level = (ServerLevel) player.getCommandSenderWorld();
 
-        List<MessengerEntity> list = level.getEntitiesOfClass(
+        for (MessengerEntity messenger : level.getEntitiesOfClass(
                 MessengerEntity.class,
-                player.getBoundingBox().inflate(16D)
-        );
+                player.getBoundingBox().inflate(16D),
+                messenger -> messenger.getUUID().equals(this.recruit) && canAnswer(player, messenger)
+        )) {
 
-        for (MessengerEntity messenger : list) {
-            if (messenger.getUUID().equals(this.recruit)) {
-                if (accepted) {
-                    handleTreatyAccepted(messenger, player, level);
-                }
-                messenger.treatyNotAccepted = !accepted;
-                messenger.teleportWaitTimer = 100;
-                player.sendSystemMessage(messenger.MESSENGER_INFO_ON_MY_WAY());
-                messenger.setMessengerState(MessengerEntity.MessengerState.TELEPORT_BACK);
-                break;
+            if (accepted) {
+                handleTreatyAccepted(messenger, player, level);
             }
+            messenger.treatyNotAccepted = !accepted;
+            messenger.teleportWaitTimer = 100;
+            player.sendSystemMessage(messenger.MESSENGER_INFO_ON_MY_WAY());
+            messenger.setMessengerState(MessengerEntity.MessengerState.TELEPORT_BACK);
+            break;
         }
+    }
+
+    private static boolean canAnswer(ServerPlayer player, MessengerEntity messenger) {
+        RecruitsFaction leaderFaction = FactionNetworkAuthority.leaderFaction(player);
+        return messenger.isTreatyMessenger()
+                && messenger.getTargetPlayerInfo() != null
+                && player.getUUID().equals(messenger.getTargetPlayerInfo().getUUID())
+                && leaderFaction != null
+                && messenger.getTargetPlayerInfo().getFaction() != null
+                && leaderFaction.getStringID().equals(messenger.getTargetPlayerInfo().getFaction().getStringID());
     }
 
     private void handleTreatyAccepted(MessengerEntity messenger, ServerPlayer player, ServerLevel level) {

--- a/src/main/java/com/talhanation/recruits/network/MessageChangeDiplomacyStatus.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageChangeDiplomacyStatus.java
@@ -6,8 +6,11 @@ import com.talhanation.recruits.world.RecruitsFaction;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.network.NetworkEvent;
+
+import java.util.Objects;
 
 
 public class MessageChangeDiplomacyStatus implements Message<MessageChangeDiplomacyStatus> {
@@ -29,9 +32,23 @@ public class MessageChangeDiplomacyStatus implements Message<MessageChangeDiplom
     }
 
     public void executeServerSide(NetworkEvent.Context context){
+        ServerPlayer player = Objects.requireNonNull(context.getSender());
+        if (!FactionNetworkAuthority.isLeaderOf(player, ownTeam)) {
+            return;
+        }
+        if (ownTeam.equals(otherTeam)) {
+            return;
+        }
+        if (FactionEvents.recruitsFactionManager.getFactionByStringID(otherTeam) == null) {
+            return;
+        }
+        if (this.status < RecruitsDiplomacyManager.DiplomacyStatus.NEUTRAL.getByteValue()
+                || this.status > RecruitsDiplomacyManager.DiplomacyStatus.ENEMY.getByteValue()) {
+            return;
+        }
         RecruitsDiplomacyManager.DiplomacyStatus status = RecruitsDiplomacyManager.DiplomacyStatus.fromByte(this.status);
 
-        FactionEvents.recruitsDiplomacyManager.setRelation(ownTeam, otherTeam, status, (ServerLevel) context.getSender().getCommandSenderWorld());
+        FactionEvents.recruitsDiplomacyManager.setRelation(ownTeam, otherTeam, status, (ServerLevel) player.getCommandSenderWorld());
 
     }
     public MessageChangeDiplomacyStatus fromBytes(FriendlyByteBuf buf) {

--- a/src/main/java/com/talhanation/recruits/network/MessageCreateTeam.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageCreateTeam.java
@@ -35,8 +35,11 @@ public class MessageCreateTeam implements Message<MessageCreateTeam> {
 
     public void executeServerSide(NetworkEvent.Context context) {
         ServerPlayer player = context.getSender();
+        if (player == null || player.getTeam() != null || this.color == null || this.index < 0 || this.index > FactionNetworkAuthority.MAX_UNIT_COLOR_INDEX) {
+            return;
+        }
         ServerLevel world = player.serverLevel();
-        FactionEvents.createTeam(true, context.getSender(), world, this.teamName, this.displayName, player.getName().getString(), this.banner, this.color, (byte) index);
+        FactionEvents.createTeam(true, player, world, this.teamName, this.displayName, player.getName().getString(), this.banner, this.color, (byte) index);
     }
 
     public MessageCreateTeam fromBytes(FriendlyByteBuf buf) {

--- a/src/main/java/com/talhanation/recruits/network/MessageRemoveFromTeam.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageRemoveFromTeam.java
@@ -1,6 +1,7 @@
 package com.talhanation.recruits.network;
 
 import com.talhanation.recruits.FactionEvents;
+import com.talhanation.recruits.world.RecruitsFaction;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerLevel;
@@ -28,12 +29,18 @@ public class MessageRemoveFromTeam implements Message<MessageRemoveFromTeam> {
     public void executeServerSide(NetworkEvent.Context context) {
         ServerPlayer sender = Objects.requireNonNull(context.getSender());
         ServerLevel level = sender.serverLevel();
+        RecruitsFaction senderFaction = FactionNetworkAuthority.leaderFaction(sender);
+        if (senderFaction == null) {
+            return;
+        }
 
         boolean foundOnline = false;
         for (ServerPlayer serverPlayer : level.players()) {
-            if (serverPlayer.getName().getString().equals(player)) {
+            if (serverPlayer.getName().getString().equals(player)
+                    && serverPlayer.getTeam() != null
+                    && serverPlayer.getTeam().getName().equals(senderFaction.getStringID())) {
                 FactionEvents.tryToRemoveFromTeam(
-                        serverPlayer.getTeam(),
+                        sender.getTeam(),
                         sender,
                         serverPlayer,
                         level,

--- a/src/main/java/com/talhanation/recruits/network/MessageSaveTeamSettings.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageSaveTeamSettings.java
@@ -1,10 +1,14 @@
 package com.talhanation.recruits.network;
 
 import com.talhanation.recruits.FactionEvents;
+import com.talhanation.recruits.config.RecruitsServerConfig;
 import com.talhanation.recruits.world.RecruitsFaction;
+import com.talhanation.recruits.world.RecruitsPlayerInfo;
 import de.maxhenkel.corelib.net.Message;
+import net.minecraft.ChatFormatting;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.network.NetworkEvent;
 
@@ -30,8 +34,44 @@ public class MessageSaveTeamSettings implements Message<MessageSaveTeamSettings>
 
     @Override
     public void executeServerSide(NetworkEvent.Context context) {
+        ServerPlayer player = context.getSender();
+        if (player == null || !FactionNetworkAuthority.isLeaderOf(player, stringID)) {
+            return;
+        }
         RecruitsFaction editedTeam = RecruitsFaction.fromNBT(nbt);
-        FactionEvents.modifyTeam(context.getSender().server.overworld(), stringID, editedTeam, context.getSender(), cost);
+        RecruitsFaction currentTeam = FactionEvents.recruitsFactionManager.getFactionByStringID(stringID);
+        if (editedTeam == null || currentTeam == null || !stringID.equals(editedTeam.getStringID())) {
+            return;
+        }
+        if (!hasValidSettings(editedTeam)) {
+            return;
+        }
+        RecruitsPlayerInfo newLeader = FactionNetworkAuthority.memberByUuid(currentTeam, new RecruitsPlayerInfo(editedTeam.getTeamLeaderUUID(), editedTeam.getTeamLeaderName()));
+        if (newLeader == null) {
+            return;
+        }
+        editedTeam.setTeamLeaderName(newLeader.getName());
+        FactionEvents.modifyTeam(player.server.overworld(), stringID, editedTeam, player, getEditCost(currentTeam, editedTeam));
+    }
+
+    private static boolean hasValidSettings(RecruitsFaction editedTeam) {
+        return editedTeam.getMaxNPCsPerPlayer() >= 0
+                && editedTeam.getMaxNPCsPerPlayer() <= RecruitsServerConfig.MaxRecruitsForPlayer.get()
+                && editedTeam.getUnitColor() >= 0
+                && editedTeam.getUnitColor() <= FactionNetworkAuthority.MAX_UNIT_COLOR_INDEX
+                && ChatFormatting.getById(editedTeam.getTeamColor()) != null;
+    }
+
+    private static int getEditCost(RecruitsFaction currentTeam, RecruitsFaction editedTeam) {
+        int cost = 0;
+        int changeCost = RecruitsServerConfig.FactionCreationCost.get();
+        if (!currentTeam.getTeamLeaderUUID().equals(editedTeam.getTeamLeaderUUID())) cost += changeCost;
+        if (!currentTeam.getTeamDisplayName().equals(editedTeam.getTeamDisplayName())) cost += changeCost;
+        if (!currentTeam.getBanner().equals(editedTeam.getBanner())) cost += changeCost;
+        if (currentTeam.getUnitColor() != editedTeam.getUnitColor()) cost += changeCost;
+        if (currentTeam.getTeamColor() != editedTeam.getTeamColor()) cost += changeCost;
+        if (currentTeam.getMaxNPCsPerPlayer() != editedTeam.getMaxNPCsPerPlayer()) cost += changeCost;
+        return cost;
     }
 
     @Override

--- a/src/main/java/com/talhanation/recruits/network/MessageSendMessenger.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageSendMessenger.java
@@ -9,7 +9,6 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.network.NetworkEvent;
 
-import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -43,25 +42,21 @@ public class MessageSendMessenger implements Message<MessageSendMessenger> {
 
     public void executeServerSide(NetworkEvent.Context context) {
         ServerPlayer player = Objects.requireNonNull(context.getSender());
-        player.getCommandSenderWorld().getEntitiesOfClass(
-                MessengerEntity.class,
-                player.getBoundingBox().inflate(16D),
-                (messenger) -> messenger.getUUID().equals(this.recruit)
-        ).forEach((messenger) -> {
-            if (messenger.getUUID().equals(this.recruit)){
+        RecruitCommandTargetResolver.resolveOwnedRecruit(player, this.recruit, 16D, false)
+                .filter(messenger -> messenger instanceof MessengerEntity)
+                .map(messenger -> (MessengerEntity) messenger)
+                .ifPresent((messenger) -> {
+                    messenger.setMessage(this.message);
 
-                messenger.setMessage(this.message);
+                    if(!this.nbt.isEmpty()){
+                        messenger.setTargetPlayerInfo(RecruitsPlayerInfo.getFromNBT(this.nbt));
+                    }
 
-                if(!this.nbt.isEmpty()){
-                    messenger.setTargetPlayerInfo(RecruitsPlayerInfo.getFromNBT(this.nbt));
-                }
-
-                if(start){
-                    messenger.setIsTreatyMessenger(false);
-                    messenger.start();
-                }
-            }
-        });
+                    if(start){
+                        messenger.setIsTreatyMessenger(false);
+                        messenger.start();
+                    }
+                });
     }
 
     public MessageSendMessenger fromBytes(FriendlyByteBuf buf) {

--- a/src/main/java/com/talhanation/recruits/network/MessageSendTreaty.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageSendTreaty.java
@@ -1,6 +1,8 @@
 package com.talhanation.recruits.network;
 
+import com.talhanation.recruits.FactionEvents;
 import com.talhanation.recruits.entities.MessengerEntity;
+import com.talhanation.recruits.world.RecruitsFaction;
 import com.talhanation.recruits.world.RecruitsPlayerInfo;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.nbt.CompoundTag;
@@ -42,24 +44,40 @@ public class MessageSendTreaty implements Message<MessageSendTreaty> {
     @Override
     public void executeServerSide(NetworkEvent.Context context) {
         ServerPlayer player = Objects.requireNonNull(context.getSender());
-        player.getCommandSenderWorld().getEntitiesOfClass(
-                MessengerEntity.class,
-                player.getBoundingBox().inflate(16D),
-                (messenger) -> messenger.getUUID().equals(this.recruit)
-        ).forEach((messenger) -> {
-            if (messenger.getUUID().equals(this.recruit)) {
+        if (this.durationHours < 0) {
+            return;
+        }
+        RecruitsPlayerInfo targetPlayer = RecruitsPlayerInfo.getFromNBT(this.targetPlayerNbt);
+        if (!isFactionLeader(targetPlayer)) {
+            return;
+        }
+        RecruitsFaction senderFaction = FactionNetworkAuthority.leaderFaction(player);
+        if (senderFaction == null) {
+            return;
+        }
+        RecruitCommandTargetResolver.resolveOwnedRecruit(player, this.recruit, 16D, false)
+                .filter(messenger -> messenger instanceof MessengerEntity)
+                .map(messenger -> (MessengerEntity) messenger)
+                .filter(messenger -> messenger.getTeam() != null && messenger.getTeam().getName().equals(senderFaction.getStringID()))
+                .ifPresent((messenger) -> {
+                    if (!this.targetPlayerNbt.isEmpty()) {
+                        messenger.setTargetPlayerInfo(targetPlayer);
+                    }
 
-                if (!this.targetPlayerNbt.isEmpty()) {
-                    messenger.setTargetPlayerInfo(RecruitsPlayerInfo.getFromNBT(this.targetPlayerNbt));
-                }
+                    if (start) {
+                        messenger.setTreatyDurationHours(this.durationHours);
+                        messenger.setIsTreatyMessenger(true);
+                        messenger.start();
+                    }
+                });
+    }
 
-                if (start) {
-                    messenger.setTreatyDurationHours(this.durationHours);
-                    messenger.setIsTreatyMessenger(true);
-                    messenger.start();
-                }
-            }
-        });
+    private static boolean isFactionLeader(RecruitsPlayerInfo playerInfo) {
+        if (playerInfo == null || playerInfo.getFaction() == null) {
+            return false;
+        }
+        RecruitsFaction faction = FactionEvents.recruitsFactionManager.getFactionByStringID(playerInfo.getFaction().getStringID());
+        return faction != null && playerInfo.getUUID().equals(faction.getTeamLeaderUUID());
     }
 
     @Override


### PR DESCRIPTION
## Summary
- Require server-side faction leader authority for diplomacy status changes, treaties, team edits, and team removals.
- Validate messenger ownership/targets and treaty participants before starting or answering messenger flows.
- Recompute team edit costs server-side and bound faction settings such as recruit caps and colors.

## Verification
- ./gradlew compileJava passed before commit.
- code-simplifier cleanup pass completed.
- code-reviewer final pass reported no findings.