### PR TITLE
Harden claim authority

### DIFF
--- a/src/main/java/com/talhanation/recruits/client/gui/worldmap/WorldMapContextMenu.java
+++ b/src/main/java/com/talhanation/recruits/client/gui/worldmap/WorldMapContextMenu.java
@@ -5,6 +5,7 @@ import com.talhanation.recruits.client.ClientManager;
 import com.talhanation.recruits.client.gui.diplomacy.DiplomacyEditScreen;
 import com.talhanation.recruits.network.MessageTeleportPlayer;
 import com.talhanation.recruits.network.MessageUpdateClaim;
+import com.talhanation.recruits.world.RecruitsClaim;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
@@ -107,9 +108,10 @@ public class WorldMapContextMenu {
                         || this.worldMapScreen.isPlayerClaimLeader(worldMapScreen.selectedClaim)),
                 (screen) -> {
                     if (screen.selectedClaim.containsChunk(screen.selectedChunk)) {
-                        screen.selectedClaim.removeChunk(screen.selectedChunk);
+                        RecruitsClaim updatedClaim = RecruitsClaim.fromNBT(screen.selectedClaim.toNBT());
+                        updatedClaim.removeChunk(screen.selectedChunk);
                         screen.selectedChunk = null;
-                        Main.SIMPLE_CHANNEL.sendToServer(new MessageUpdateClaim(screen.selectedClaim));
+                        Main.SIMPLE_CHANNEL.sendToServer(new MessageUpdateClaim(updatedClaim));
                     }
                 }
         );
@@ -124,9 +126,10 @@ public class WorldMapContextMenu {
                         || this.worldMapScreen.isPlayerClaimLeader(worldMapScreen.selectedClaim)),
                 (screen) -> {
                     if (screen.selectedClaim.containsChunk(screen.selectedChunk)) {
-                        screen.selectedClaim.removeChunk(screen.selectedChunk);
+                        RecruitsClaim updatedClaim = RecruitsClaim.fromNBT(screen.selectedClaim.toNBT());
+                        updatedClaim.removeChunk(screen.selectedChunk);
                         screen.selectedChunk = null;
-                        Main.SIMPLE_CHANNEL.sendToServer(new MessageUpdateClaim(screen.selectedClaim));
+                        Main.SIMPLE_CHANNEL.sendToServer(new MessageUpdateClaim(updatedClaim));
                     }
                 },
                 "admin"
@@ -135,8 +138,9 @@ public class WorldMapContextMenu {
         addEntry(TEXT_DELETE_CLAIM_ADMIN.getString(),
                 () -> this.worldMapScreen.isPlayerAdminAndCreative() && this.worldMapScreen.selectedClaim != null,
                 (screen) -> {
-                    screen.selectedClaim.isRemoved = true;
-                    Main.SIMPLE_CHANNEL.sendToServer(new MessageUpdateClaim(screen.selectedClaim));
+                    RecruitsClaim updatedClaim = RecruitsClaim.fromNBT(screen.selectedClaim.toNBT());
+                    updatedClaim.isRemoved = true;
+                    Main.SIMPLE_CHANNEL.sendToServer(new MessageUpdateClaim(updatedClaim));
                     screen.selectedClaim = null;
                 },
                 "admin"

--- a/src/main/java/com/talhanation/recruits/client/gui/worldmap/WorldMapScreen.java
+++ b/src/main/java/com/talhanation/recruits/client/gui/worldmap/WorldMapScreen.java
@@ -9,7 +9,6 @@ import com.talhanation.recruits.Main;
 import com.talhanation.recruits.client.ClientManager;
 import com.talhanation.recruits.client.gui.widgets.DropDownMenu;
 import com.talhanation.recruits.compat.smallships.SmallShips;
-import com.talhanation.recruits.network.MessageDoPayment;
 import com.talhanation.recruits.network.MessageUpdateClaim;
 import com.talhanation.recruits.world.RecruitsClaim;
 import com.talhanation.recruits.world.RecruitsFaction;
@@ -859,8 +858,6 @@ public class WorldMapScreen extends Screen {
             for (ChunkPos pos : area) newClaim.addChunk(pos);
             newClaim.setCenter(selectedChunk);
             newClaim.setPlayer(new RecruitsPlayerInfo(player.getUUID(), player.getName().getString(), ownFaction));
-            Main.SIMPLE_CHANNEL.sendToServer(new MessageDoPayment(player.getUUID(), getClaimCost(ownFaction)));
-            ClientManager.recruitsClaims.add(newClaim);
             Main.SIMPLE_CHANNEL.sendToServer(new MessageUpdateClaim(newClaim));
         }
 
@@ -871,15 +868,10 @@ public class WorldMapScreen extends Screen {
             RecruitsClaim neighborClaim = getNeighborClaim(selectedChunk);
             if (neighborClaim == null) return;
             if (!Objects.equals(ownFaction.getStringID(), neighborClaim.getOwnerFaction().getStringID())) return;
-            for (RecruitsClaim claim : ClientManager.recruitsClaims) {
-                if (claim.equals(neighborClaim)) {
-                    neighborClaim.addChunk(selectedChunk);
-                    recalculateCenter(neighborClaim);
-                    break;
-                }
-            }
-            Main.SIMPLE_CHANNEL.sendToServer(new MessageDoPayment(player.getUUID(), ClientManager.configValueChunkCost));
-            Main.SIMPLE_CHANNEL.sendToServer(new MessageUpdateClaim(neighborClaim));
+            RecruitsClaim updatedClaim = RecruitsClaim.fromNBT(neighborClaim.toNBT());
+            updatedClaim.addChunk(selectedChunk);
+            recalculateCenter(updatedClaim);
+            Main.SIMPLE_CHANNEL.sendToServer(new MessageUpdateClaim(updatedClaim));
         }
 
         @Nullable
@@ -1033,4 +1025,3 @@ public class WorldMapScreen extends Screen {
             return !isInBufferZone(pos, ClientManager.ownFaction);
         }
     }
-

--- a/src/main/java/com/talhanation/recruits/network/ClaimNetworkAuthority.java
+++ b/src/main/java/com/talhanation/recruits/network/ClaimNetworkAuthority.java
@@ -1,0 +1,178 @@
+package com.talhanation.recruits.network;
+
+import com.talhanation.recruits.ClaimEvents;
+import com.talhanation.recruits.FactionEvents;
+import com.talhanation.recruits.config.RecruitsServerConfig;
+import com.talhanation.recruits.world.RecruitsClaim;
+import com.talhanation.recruits.world.RecruitsFaction;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.ChunkPos;
+
+import javax.annotation.Nullable;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+final class ClaimNetworkAuthority {
+    private ClaimNetworkAuthority() {
+    }
+
+    @Nullable
+    static RecruitsClaim readClaim(CompoundTag nbt) {
+        try {
+            return RecruitsClaim.fromNBT(nbt);
+        }
+        catch (RuntimeException e) {
+            return null;
+        }
+    }
+
+    @Nullable
+    static RecruitsFaction senderFaction(ServerPlayer player) {
+        if (player == null || player.getTeam() == null) {
+            return null;
+        }
+        return FactionEvents.recruitsFactionManager.getFactionByStringID(player.getTeam().getName());
+    }
+
+    @Nullable
+    static RecruitsClaim claimByUuid(UUID claimId) {
+        if (claimId == null) {
+            return null;
+        }
+        return ClaimEvents.recruitsClaimManager.getAllClaims().stream()
+                .filter(claim -> claimId.equals(claim.getUUID()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    static boolean canManageClaim(ServerPlayer player, RecruitsClaim claim) {
+        if (player == null || claim == null || claim.getOwnerFaction() == null) {
+            return false;
+        }
+        RecruitsFaction senderFaction = senderFaction(player);
+        if (senderFaction == null || !senderFaction.getStringID().equals(claim.getOwnerFactionStringID())) {
+            return false;
+        }
+        if (player.getUUID().equals(senderFaction.getTeamLeaderUUID())) {
+            return true;
+        }
+        return claim.getPlayerInfo() != null
+                && player.getUUID().equals(claim.getPlayerInfo().getUUID())
+                && FactionNetworkAuthority.memberByUuid(senderFaction, claim.getPlayerInfo()) != null;
+    }
+
+    static boolean isCreativeAdmin(ServerPlayer player) {
+        return player != null && player.isCreative() && player.hasPermissions(2);
+    }
+
+    static boolean pay(ServerPlayer player, int cost) {
+        if (cost <= 0 || isCreativeAdmin(player)) {
+            return true;
+        }
+        if (!FactionEvents.playerHasEnoughEmeralds(player, cost)) {
+            return false;
+        }
+        FactionEvents.doPayment(player, cost);
+        return true;
+    }
+
+    static int newClaimCost(RecruitsFaction ownerFaction) {
+        if (!RecruitsServerConfig.CascadeThePriceOfClaims.get()) {
+            return RecruitsServerConfig.ClaimingCost.get();
+        }
+        int amount = 1;
+        for (RecruitsClaim claim : ClaimEvents.recruitsClaimManager.getAllClaims()) {
+            if (claim.getOwnerFaction() != null && claim.getOwnerFactionStringID().equals(ownerFaction.getStringID())) {
+                amount++;
+            }
+        }
+        return amount * RecruitsServerConfig.ClaimingCost.get();
+    }
+
+    static boolean isNearPlayer(ServerPlayer player, ChunkPos pos) {
+        if (player == null || pos == null) {
+            return false;
+        }
+        ChunkPos playerChunk = player.chunkPosition();
+        return Math.abs(playerChunk.x - pos.x) <= 4 && Math.abs(playerChunk.z - pos.z) <= 4;
+    }
+
+    static boolean isFiveByFiveArea(ChunkPos center, List<ChunkPos> chunks) {
+        if (center == null || chunks == null || chunks.size() != 25) {
+            return false;
+        }
+        Set<ChunkPos> chunkSet = new HashSet<>(chunks);
+        if (chunkSet.size() != 25) {
+            return false;
+        }
+        for (int dx = -2; dx <= 2; dx++) {
+            for (int dz = -2; dz <= 2; dz++) {
+                if (!chunkSet.contains(new ChunkPos(center.x + dx, center.z + dz))) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    static boolean hasForeignBufferConflict(RecruitsFaction ownerFaction, List<ChunkPos> chunks) {
+        for (ChunkPos chunk : chunks) {
+            if (hasForeignBufferConflict(ownerFaction, chunk)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static boolean hasForeignBufferConflict(RecruitsFaction ownerFaction, ChunkPos chunk) {
+        for (RecruitsClaim claim : ClaimEvents.recruitsClaimManager.getAllClaims()) {
+            if (claim.getOwnerFaction() == null || claim.getOwnerFactionStringID().equals(ownerFaction.getStringID())) {
+                continue;
+            }
+            for (ChunkPos claimChunk : claim.getClaimedChunks()) {
+                int dx = Math.abs(chunk.x - claimChunk.x);
+                int dz = Math.abs(chunk.z - claimChunk.z);
+                if (dx <= 3 && dz <= 3 && !(dx == 0 && dz == 0)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    static boolean canRemoveChunk(RecruitsClaim claim, ChunkPos chunk) {
+        if (claim == null || chunk == null || !claim.containsChunk(chunk)) {
+            return false;
+        }
+        int unclaimedNeighbors = 0;
+        for (ChunkPos neighbor : new ChunkPos[]{
+                new ChunkPos(chunk.x + 1, chunk.z), new ChunkPos(chunk.x - 1, chunk.z),
+                new ChunkPos(chunk.x, chunk.z + 1), new ChunkPos(chunk.x, chunk.z - 1)}) {
+            if (!claim.containsChunk(neighbor)) {
+                unclaimedNeighbors++;
+            }
+        }
+        return unclaimedNeighbors >= 2;
+    }
+
+    static void recalculateCenter(RecruitsClaim claim) {
+        List<ChunkPos> chunks = claim.getClaimedChunks();
+        if (chunks.isEmpty()) {
+            return;
+        }
+        int minX = Integer.MAX_VALUE;
+        int maxX = Integer.MIN_VALUE;
+        int minZ = Integer.MAX_VALUE;
+        int maxZ = Integer.MIN_VALUE;
+        for (ChunkPos pos : chunks) {
+            minX = Math.min(minX, pos.x);
+            maxX = Math.max(maxX, pos.x);
+            minZ = Math.min(minZ, pos.z);
+            maxZ = Math.max(maxZ, pos.z);
+        }
+        claim.setCenter(new ChunkPos((minX + maxX) / 2, (minZ + maxZ) / 2));
+    }
+}

--- a/src/main/java/com/talhanation/recruits/network/MessageDeleteClaim.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageDeleteClaim.java
@@ -6,6 +6,7 @@ import de.maxhenkel.corelib.net.Message;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.network.NetworkEvent;
 
@@ -27,11 +28,18 @@ public class MessageDeleteClaim implements Message<MessageDeleteClaim> {
     }
 
     public void executeServerSide(NetworkEvent.Context context){
-        RecruitsClaim claim = RecruitsClaim.fromNBT(this.claimNBT);
+        ServerPlayer player = context.getSender();
+        if (player == null || this.claimNBT == null || this.claimNBT.isEmpty()) return;
+        RecruitsClaim requestedClaim = ClaimNetworkAuthority.readClaim(this.claimNBT);
+        if (requestedClaim == null) return;
+        RecruitsClaim claim = ClaimNetworkAuthority.claimByUuid(requestedClaim.getUUID());
+        if (claim == null) return;
+        if (!ClaimNetworkAuthority.isCreativeAdmin(player)) return;
 
         ClaimEvents.recruitsClaimManager.removeClaim(claim);
-        ClaimEvents.recruitsClaimManager.broadcastClaimsToAll((ServerLevel) context.getSender().getCommandSenderWorld());
+        ClaimEvents.recruitsClaimManager.broadcastClaimsToAll((ServerLevel) player.getCommandSenderWorld());
     }
+
     public MessageDeleteClaim fromBytes(FriendlyByteBuf buf) {
         this.claimNBT = buf.readNbt();
         return this;

--- a/src/main/java/com/talhanation/recruits/network/MessageUpdateClaim.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageUpdateClaim.java
@@ -1,17 +1,23 @@
 package com.talhanation.recruits.network;
 
 import com.talhanation.recruits.ClaimEvents;
-import com.talhanation.recruits.client.ClientManager;
 import com.talhanation.recruits.config.RecruitsServerConfig;
 import com.talhanation.recruits.world.RecruitsClaim;
+import com.talhanation.recruits.world.RecruitsFaction;
+import com.talhanation.recruits.world.RecruitsPlayerInfo;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.network.NetworkEvent;
 
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 public class MessageUpdateClaim implements Message<MessageUpdateClaim> {
 
@@ -30,12 +36,138 @@ public class MessageUpdateClaim implements Message<MessageUpdateClaim> {
     }
 
     public void executeServerSide(NetworkEvent.Context context){
-        RecruitsClaim updatedClaim = RecruitsClaim.fromNBT(this.claimNBT);
+        ServerPlayer player = context.getSender();
+        if (player == null || this.claimNBT == null || this.claimNBT.isEmpty()) return;
         if(!RecruitsServerConfig.AllowClaiming.get()) return;
-        if(context.getSender().level().dimension() != Level.OVERWORLD) return;
+        if(player.level().dimension() != Level.OVERWORLD) return;
 
-        ClaimEvents.recruitsClaimManager.addOrUpdateClaim((ServerLevel) context.getSender().getCommandSenderWorld(), updatedClaim);
+        RecruitsClaim requestedClaim = ClaimNetworkAuthority.readClaim(this.claimNBT);
+        if (requestedClaim == null || requestedClaim.getCenter() == null || requestedClaim.getClaimedChunks().isEmpty()) return;
+
+        ServerLevel level = (ServerLevel) player.getCommandSenderWorld();
+        RecruitsClaim currentClaim = ClaimNetworkAuthority.claimByUuid(requestedClaim.getUUID());
+        if (currentClaim == null) {
+            handleNewClaim(player, level, requestedClaim);
+        }
+        else {
+            handleExistingClaim(player, level, currentClaim, requestedClaim);
+        }
     }
+
+    private static void handleNewClaim(ServerPlayer player, ServerLevel level, RecruitsClaim requestedClaim) {
+        RecruitsFaction ownerFaction = FactionNetworkAuthority.leaderFaction(player);
+        List<ChunkPos> requestedChunks = requestedClaim.getClaimedChunks();
+        if (ownerFaction == null) return;
+        if (!ClaimNetworkAuthority.isFiveByFiveArea(requestedClaim.getCenter(), requestedChunks)) return;
+        if (!ClaimNetworkAuthority.isNearPlayer(player, requestedClaim.getCenter())) return;
+        if (ClaimEvents.recruitsClaimManager.claimExists(requestedClaim, requestedChunks)) return;
+        if (ClaimNetworkAuthority.hasForeignBufferConflict(ownerFaction, requestedChunks)) return;
+
+        RecruitsClaim newClaim = new RecruitsClaim(ownerFaction);
+        newClaim.setCenter(requestedClaim.getCenter());
+        newClaim.setPlayer(new RecruitsPlayerInfo(player.getUUID(), player.getName().getString(), ownerFaction));
+        for (ChunkPos chunk : requestedChunks) {
+            newClaim.addChunk(chunk);
+        }
+        int claimCost = ClaimNetworkAuthority.newClaimCost(ownerFaction);
+        ClaimEvents.recruitsClaimManager.tryAddOrUpdateClaim(level, newClaim, () -> ClaimNetworkAuthority.pay(player, claimCost));
+    }
+
+    private static void handleExistingClaim(ServerPlayer player, ServerLevel level, RecruitsClaim currentClaim, RecruitsClaim requestedClaim) {
+        if (requestedClaim.isRemoved) {
+            if (!ClaimNetworkAuthority.isCreativeAdmin(player)) return;
+            ClaimEvents.recruitsClaimManager.removeClaim(currentClaim);
+            ClaimEvents.recruitsClaimManager.broadcastClaimsToAll(level);
+            return;
+        }
+
+        if (currentClaim.getOwnerFaction() == null) return;
+        if (!ClaimNetworkAuthority.canManageClaim(player, currentClaim) && !ClaimNetworkAuthority.isCreativeAdmin(player)) return;
+        if (requestedClaim.getOwnerFaction() != null
+                && !requestedClaim.getOwnerFactionStringID().equals(currentClaim.getOwnerFactionStringID())) {
+            return;
+        }
+
+        Set<ChunkPos> currentChunks = new HashSet<>(currentClaim.getClaimedChunks());
+        Set<ChunkPos> requestedChunks = new HashSet<>(requestedClaim.getClaimedChunks());
+        Set<ChunkPos> addedChunks = new HashSet<>(requestedChunks);
+        addedChunks.removeAll(currentChunks);
+        Set<ChunkPos> removedChunks = new HashSet<>(currentChunks);
+        removedChunks.removeAll(requestedChunks);
+        RecruitsClaim updatedClaim = RecruitsClaim.fromNBT(currentClaim.toNBT());
+        int paymentCost = 0;
+
+        boolean updated;
+        if (addedChunks.isEmpty() && removedChunks.isEmpty()) {
+            if (!applyEditableMetadata(updatedClaim, requestedClaim)) return;
+            updated = true;
+        }
+        else if (addedChunks.size() == 1 && removedChunks.isEmpty()) {
+            updated = addChunk(player, updatedClaim, requestedClaim, addedChunks.iterator().next());
+            paymentCost = RecruitsServerConfig.ChunkCost.get();
+        }
+        else if (addedChunks.isEmpty() && removedChunks.size() == 1) {
+            updated = removeChunk(player, updatedClaim, requestedClaim, removedChunks.iterator().next());
+        }
+        else {
+            return;
+        }
+
+        if (!updated) return;
+        int cost = paymentCost;
+        ClaimEvents.recruitsClaimManager.tryAddOrUpdateClaim(level, updatedClaim, () -> ClaimNetworkAuthority.pay(player, cost));
+    }
+
+    private static boolean addChunk(ServerPlayer player, RecruitsClaim currentClaim, RecruitsClaim requestedClaim, ChunkPos chunk) {
+        if (currentClaim.getClaimedChunks().size() >= RecruitsClaim.MAX_SIZE) return false;
+        if (!ClaimNetworkAuthority.isNearPlayer(player, chunk)) return false;
+        if (ClaimEvents.recruitsClaimManager.getClaim(chunk) != null) return false;
+        if (!hasNeighbor(currentClaim, chunk)) return false;
+        if (ClaimNetworkAuthority.hasForeignBufferConflict(currentClaim.getOwnerFaction(), chunk)) return false;
+        if (!applyEditableMetadata(currentClaim, requestedClaim)) return false;
+
+        currentClaim.addChunk(chunk);
+        ClaimNetworkAuthority.recalculateCenter(currentClaim);
+        return true;
+    }
+
+    private static boolean removeChunk(ServerPlayer player, RecruitsClaim currentClaim, RecruitsClaim requestedClaim, ChunkPos chunk) {
+        if (!ClaimNetworkAuthority.isNearPlayer(player, chunk)) return false;
+        if (!ClaimNetworkAuthority.canRemoveChunk(currentClaim, chunk)) return false;
+        if (!applyEditableMetadata(currentClaim, requestedClaim)) return false;
+        currentClaim.removeChunk(chunk);
+        ClaimNetworkAuthority.recalculateCenter(currentClaim);
+        return true;
+    }
+
+    private static boolean hasNeighbor(RecruitsClaim claim, ChunkPos chunk) {
+        return claim.containsChunk(new ChunkPos(chunk.x + 1, chunk.z))
+                || claim.containsChunk(new ChunkPos(chunk.x - 1, chunk.z))
+                || claim.containsChunk(new ChunkPos(chunk.x, chunk.z + 1))
+                || claim.containsChunk(new ChunkPos(chunk.x, chunk.z - 1));
+    }
+
+    private static boolean applyEditableMetadata(RecruitsClaim currentClaim, RecruitsClaim requestedClaim) {
+        if (requestedClaim.getName() == null || requestedClaim.getName().isBlank() || requestedClaim.getName().length() > 32) {
+            return false;
+        }
+        RecruitsPlayerInfo requestedPlayer = requestedClaim.getPlayerInfo();
+        RecruitsPlayerInfo member = null;
+        if (requestedPlayer != null) {
+            member = FactionNetworkAuthority.memberByUuid(currentClaim.getOwnerFaction(), requestedPlayer);
+            if (member == null) return false;
+        }
+
+        currentClaim.setName(requestedClaim.getName());
+        if (member != null) {
+            currentClaim.setPlayer(new RecruitsPlayerInfo(member.getUUID(), member.getName(), currentClaim.getOwnerFaction()));
+        }
+        currentClaim.setBlockInteractionAllowed(requestedClaim.isBlockInteractionAllowed());
+        currentClaim.setBlockPlacementAllowed(requestedClaim.isBlockPlacementAllowed());
+        currentClaim.setBlockBreakingAllowed(requestedClaim.isBlockBreakingAllowed());
+        return true;
+    }
+
     public MessageUpdateClaim fromBytes(FriendlyByteBuf buf) {
         this.claimNBT = buf.readNbt();
         return this;

--- a/src/main/java/com/talhanation/recruits/world/RecruitsClaimManager.java
+++ b/src/main/java/com/talhanation/recruits/world/RecruitsClaimManager.java
@@ -15,6 +15,7 @@ import net.minecraftforge.network.PacketDistributor;
 
 import javax.annotation.Nullable;
 import java.util.*;
+import java.util.function.BooleanSupplier;
 public class RecruitsClaimManager {
     private final Map<ChunkPos, RecruitsClaim> claims = new HashMap<>();
     private final Map<UUID, RecruitsClaim> activeSieges = new HashMap<>();
@@ -40,12 +41,17 @@ public class RecruitsClaimManager {
     }
 
     public void addOrUpdateClaim(ServerLevel level, RecruitsClaim claim) {
-        if (claim == null) return;
+        tryAddOrUpdateClaim(level, claim, () -> true);
+    }
+
+    public boolean tryAddOrUpdateClaim(ServerLevel level, RecruitsClaim claim, BooleanSupplier beforeCommit) {
+        if (claim == null) return false;
 
         // ClaimEvent.Updated feuern – cancelable
         boolean isNew = claims.values().stream().noneMatch(c -> c.getUUID().equals(claim.getUUID()));
         ClaimEvent.Updated updateEvent = new ClaimEvent.Updated(claim, level, isNew);
-        if (MinecraftForge.EVENT_BUS.post(updateEvent)) return;
+        if (MinecraftForge.EVENT_BUS.post(updateEvent)) return false;
+        if (!beforeCommit.getAsBoolean()) return false;
 
         claims.entrySet().removeIf(entry -> entry.getValue().getUUID().equals(claim.getUUID()));
 
@@ -56,6 +62,7 @@ public class RecruitsClaimManager {
         }
 
         this.broadcastClaimsToAll(level);
+        return true;
     }
 
     public void removeClaim(RecruitsClaim claim) {


### PR DESCRIPTION
## Summary
- Move claim create/expand payment and validation server-side instead of trusting client claim NBT or client payment packets.
- Require server-authoritative claim/faction/admin checks for update/delete paths and reject malformed claim NBT safely.
- Avoid optimistic local world-map claim mutation before server acceptance.
- Add a claim-manager commit hook so cancelable claim update events run before payment/state commit.

## Review note
- Server-side chunk removal intentionally keeps the existing world-map proximity rule from `WorldMapScreen.canRemoveChunk()` so forged packets cannot remove chunks from anywhere.

## Verification
- ./gradlew compileJava passed.
- code-simplifier final pass completed.
- code-reviewer final pass: one proximity finding reviewed as intentional parity with existing client gating; previous findings resolved.